### PR TITLE
Bot deaths are not a statistic (fixes #176)

### DIFF
--- a/awpy/analytics/stats.py
+++ b/awpy/analytics/stats.py
@@ -153,7 +153,8 @@ def player_stats(game_rounds, return_type="json"):
                 and k["attackerSteamID"] in player_statistics.keys()
             ):
                 player_statistics[k["attackerSteamID"]]["firstKills"] += 1
-                player_statistics[k["victimSteamID"]]["firstDeaths"] += 1
+                if k["victimSteamID"] in player_statistics.keys():
+                    player_statistics[k["victimSteamID"]]["firstDeaths"] += 1
             if (
                 k["isTeamkill"]
                 and k["attackerSteamID"]


### PR DESCRIPTION
This fixes #176 by ignoring the first-death stat when the victim is a bot player.