### PR TITLE
Improvements to distance matrices

### DIFF
--- a/awpy/analytics/nav.py
+++ b/awpy/analytics/nav.py
@@ -558,17 +558,17 @@ def generate_area_distance_matrix(map_name: str, *, save: bool = False) -> AreaM
             # Compute center of second area
             area2_x, area2_y, area2_z = _get_area_center(map_name, area2)
             # Calculate basic euclidean distance
-            area_distance_matrix[str(area1)][str(area2)]["euclidean"] = math.sqrt(
+            area_distance_matrix[area1][area2]["euclidean"] = math.sqrt(
                 (area1_x - area2_x) ** 2
                 + (area1_y - area2_y) ** 2
                 + (area1_z - area2_z) ** 2
             )
             # Also get graph distance
-            area_distance_matrix[str(area1)][str(area2)]["graph"] = area_distance(
+            area_distance_matrix[area1][area2]["graph"] = area_distance(
                 map_name, area1, area2, dist_type="graph"
             )["distance"]
             # And geodesic like distance
-            area_distance_matrix[str(area1)][str(area2)]["geodesic"] = area_distance(
+            area_distance_matrix[area1][area2]["geodesic"] = area_distance(
                 map_name, area1, area2, dist_type="geodesic"
             )["distance"]
     if save:
@@ -639,7 +639,7 @@ def _get_median_place_distance(
     connections = []
     for sub_area1 in area_mapping[place1]:
         connections.extend(
-            AREA_DIST_MATRIX[map_name][str(sub_area1)][str(sub_area2)][dist_type]
+            AREA_DIST_MATRIX[map_name][sub_area1][sub_area2][dist_type]
             for sub_area2 in area_mapping[place2]
         )
     return median(connections)
@@ -706,14 +706,10 @@ def generate_place_distance_matrix(map_name: str, *, save: bool = False) -> Plac
                 else:
                     place_distance_matrix[place1][place2][dist_type][
                         "centroid"
-                    ] = AREA_DIST_MATRIX[map_name][str(centroid1)][str(centroid2)][
-                        dist_type
-                    ]
+                    ] = AREA_DIST_MATRIX[map_name][centroid1][centroid2][dist_type]
                     place_distance_matrix[place1][place2][dist_type][
                         "representative_point"
-                    ] = AREA_DIST_MATRIX[map_name][str(reps[place1])][
-                        str(reps[place2])
-                    ][
+                    ] = AREA_DIST_MATRIX[map_name][reps[place1]][reps[place2]][
                         dist_type
                     ]
                     place_distance_matrix[place1][place2][dist_type][
@@ -946,7 +942,7 @@ def _check_arguments_position_distance(
         ValueError: If number of features is not 3 for euclidean distance_type
 
     Returns:
-       tuple[npt.NDArray, npt.NDArray]: Potentially reordered position arrays.
+        tuple[npt.NDArray, npt.NDArray]: Potentially reordered position arrays.
     """
     if map_name not in NAV:
         msg = "Map not found."
@@ -1110,8 +1106,8 @@ def _graph_based_position_distance(
         )
     else:
         this_dist = min(
-            AREA_DIST_MATRIX[map_name][str(area1)][str(area2)][distance_type],
-            AREA_DIST_MATRIX[map_name][str(area2)][str(area1)][distance_type],
+            AREA_DIST_MATRIX[map_name][area1][area2][distance_type],
+            AREA_DIST_MATRIX[map_name][area2][area1][distance_type],
         )
     if this_dist == float("inf"):
         this_dist = sys.maxsize / 6
@@ -1147,10 +1143,10 @@ def position_state_distance(
 
     Raises:
         ValueError: If map_name is not in awpy.data.NAV.
-        ValueError: If distance_type is not one of ["graph", "geodesic", "euclidean"].
-        ValueError: If the 0th (number of teams) and 2nd (number of features) dimensions
+                    If distance_type is not one of ["graph", "geodesic", "euclidean"].
+                    If the 0th (number of teams) and 2nd (number of features) dimensions
                         of the inputs do not have the same size.
-        ValueError: If number of features is not 3 for euclidean distance_type
+                    If number of features is not 3 for euclidean distance_type
     """
     position_array_1, position_array_2 = _check_arguments_position_distance(
         map_name, position_array_1, position_array_2, distance_type

--- a/awpy/types.py
+++ b/awpy/types.py
@@ -62,7 +62,7 @@ class Area(TypedDict):
 
 
 DistanceType = Literal["graph", "geodesic", "euclidean"]
-AreaMatrix = dict[str, dict[str, dict[DistanceType, float]]]
+AreaMatrix = dict[int, dict[int, dict[DistanceType, float]]]
 PlaceMatrix = dict[
     str,
     dict[

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -25,7 +25,7 @@ from awpy.analytics.nav import (
     token_state_distance,
     tree,
 )
-from awpy.data import NAV, create_nav_graphs
+from awpy.data import NAV, PLACE_DIST_MATRIX, create_nav_graphs
 
 
 class TestNav:
@@ -809,6 +809,29 @@ class TestNav:
         assert self.expected_place_matrix_2 == result_matrix_2
         with pytest.raises(ValueError, match="Map not found."):
             _ = generate_place_distance_matrix("de_does_not_exist")
+
+        with patch("awpy.analytics.nav.AREA_DIST_MATRIX", {}):
+            for map_name in PLACE_DIST_MATRIX:
+                result_matrix = generate_place_distance_matrix(
+                    map_name=map_name, save=False
+                )
+                for place1_name in PLACE_DIST_MATRIX[map_name]:
+                    for place2_name in PLACE_DIST_MATRIX[map_name][place1_name]:
+                        for dist_type in PLACE_DIST_MATRIX[map_name][place1_name][
+                            place2_name
+                        ]:
+                            for ref_point in ["centroid", "representative_point"]:
+                                assert (
+                                    PLACE_DIST_MATRIX[map_name][place1_name][
+                                        place2_name
+                                    ][dist_type][ref_point]
+                                    == result_matrix[place1_name][place2_name][
+                                        dist_type
+                                    ][ref_point]
+                                ), (
+                                    f"{map_name}, {place1_name}, {place2_name},"
+                                    f" {dist_type}, {ref_point}"
+                                )
 
     def test_generate_centroids(self):
         """Tests generate centroids."""

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -94,28 +94,28 @@ class TestNav:
         )
 
         self.expected_area_matrix = {
-            "1": {
-                "1": {"euclidean": 0, "graph": 0, "geodesic": 0},
-                "2": {"euclidean": 1.0, "graph": 1.0, "geodesic": 1.0},
-                "3": {"euclidean": 2.0, "graph": 1.0, "geodesic": 2.0},
+            1: {
+                1: {"euclidean": 0, "graph": 0, "geodesic": 0},
+                2: {"euclidean": 1.0, "graph": 1.0, "geodesic": 1.0},
+                3: {"euclidean": 2.0, "graph": 1.0, "geodesic": 2.0},
             },
-            "2": {
-                "1": {
+            2: {
+                1: {
                     "euclidean": 1.0,
                     "graph": float("inf"),
                     "geodesic": float("inf"),
                 },
-                "2": {"euclidean": 0, "graph": 0, "geodesic": 0},
-                "3": {
+                2: {"euclidean": 0, "graph": 0, "geodesic": 0},
+                3: {
                     "euclidean": math.sqrt(5),
                     "graph": float("inf"),
                     "geodesic": float("inf"),
                 },
             },
-            "3": {
-                "1": {"euclidean": 2.0, "graph": 1.0, "geodesic": 2.0},
-                "2": {"euclidean": math.sqrt(5), "graph": 2.0, "geodesic": 3.0},
-                "3": {"euclidean": 0, "graph": 0, "geodesic": 0},
+            3: {
+                1: {"euclidean": 2.0, "graph": 1.0, "geodesic": 2.0},
+                2: {"euclidean": math.sqrt(5), "graph": 2.0, "geodesic": 3.0},
+                3: {"euclidean": 0, "graph": 0, "geodesic": 0},
             },
         }
         self.expected_place_matrix_1 = {
@@ -742,11 +742,9 @@ class TestNav:
 
         assert isinstance(result_matrix, dict)
         for area1_id in result_matrix:
-            assert isinstance(area1_id, str)
-            assert str(int(area1_id)) == area1_id
+            assert isinstance(area1_id, int)
             for area2_id in result_matrix[area1_id]:
-                assert isinstance(area2_id, str)
-                assert str(int(area2_id)) == area2_id
+                assert isinstance(area2_id, int)
                 for dist_type in result_matrix[area1_id][area2_id]:
                     assert dist_type in {"geodesic", "euclidean", "graph"}
                     assert isinstance(


### PR DESCRIPTION
The main work in this PR is some added verbosity to the distance matrix calculations that now print which place/area they are currently calculating distances from.

Additionally i added a test that compares the contents of the precalculated place matrices with what the generate function produces. Differences highlight changes in the nav meshes or graph definition that should be investigated.


Lastly the median_dist section of the place distance matrices takes as long to compute as the full AREA_DIST_MATRIX while the other options are significantly faster. The median_dist is now set to 0.0 if no AREA_DIST_MATRIX is present to speed up the calculation.