### PR TITLE
Fixing issue with player_stats when round[side]["players"] is None

### DIFF
--- a/awpy/analytics/stats.py
+++ b/awpy/analytics/stats.py
@@ -193,7 +193,7 @@ def player_stats(
                 k["victimSide"] in active_sides
                 # mypy does not understand that after the first part k["victimSide"] is Literal["CT", "T"]
                 # and that `k["victimSide"].lower() + "Side"` leads to a Literal["ctSide", "tSide"]
-                and len(r[k["victimSide"].lower() + "Side"]["players"])  # type: ignore[literal-required]
+                and len(r[k["victimSide"].lower() + "Side"]["players"] or [])  # type: ignore[literal-required]
                 - len(players_killed[k["victimSide"]])  # type: ignore[literal-required, index]
                 == 1
             ):
@@ -210,7 +210,7 @@ def player_stats(
                     ):
                         is_clutching.add(clutcher_key)
                         enemies_alive = len(
-                            r[other_side(k["victimSide"]).lower() + "Side"]["players"]  # type: ignore
+                            r[other_side(k["victimSide"]).lower() + "Side"]["players"] or []  # type: ignore
                         ) - len(
                             players_killed[other_side(k["victimSide"])]  # type: ignore
                         )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -65,7 +65,7 @@ class TestStats:
         with pytest.raises(ValueError):
             other_side("apple")
 
-    def test_player_stats(self):
+    def test_player_stats_general(self):
         """Tests player stats generation"""
         stats = player_stats(self.data["gameRounds"])
         assert isinstance(stats, dict)
@@ -290,3 +290,372 @@ class TestStats:
         stats = player_stats(test_rounds)
         assert stats["76561198049899734"]["suicides"] == 1
         assert isinstance(stats_df, pd.DataFrame)
+
+    def test_player_stats_consistency(self):
+        """Tests that player stats are self consistent"""
+        stats = player_stats(self.data["gameRounds"])
+
+        stats_ct = player_stats(self.data["gameRounds"], selected_side="ct")
+
+        stats_t = player_stats(self.data["gameRounds"], selected_side="T")
+
+        for player in stats:
+            for metric in stats[player]:
+                total_value = stats[player][metric]
+                t_value = stats_t[player][metric]
+                ct_value = stats_ct[player][metric]
+                # All numerical purely cummulative values should add up
+                if isinstance(total_value, numbers.Number) and metric not in {
+                    "kast",
+                    "rating",
+                    "adr",
+                    "accuracy",
+                    "isBot",
+                    "kdr",
+                    "hsPercent",
+                    "steamID",
+                }:
+                    # Allow for slight deviation in case of rounding
+                    assert isclose(total_value, (t_value + ct_value), abs_tol=0.11)
+                elif metric in {"steamID", "isBot"}:
+                    assert total_value == t_value and total_value == ct_value
+                elif metric in {"playerName", "teamName"}:
+                    assert total_value in {t_value, ct_value}
+                elif metric in {"kast", "adr"}:
+                    assert isclose(
+                        total_value,
+                        weighted_avg(
+                            metric, "totalRounds", stats_t[player], stats_ct[player]
+                        ),
+                        abs_tol=0.11,
+                    )
+                elif metric == "hsPercent":
+                    assert isclose(
+                        total_value,
+                        weighted_avg(
+                            metric, "kills", stats_t[player], stats_ct[player]
+                        ),
+                        abs_tol=0.11,
+                    )
+                elif metric == "kdr":
+                    assert isclose(
+                        total_value,
+                        weighted_avg(
+                            metric, "deaths", stats_t[player], stats_ct[player]
+                        ),
+                        abs_tol=0.11,
+                    )
+                elif metric == "accuracy":
+                    assert isclose(
+                        total_value,
+                        weighted_avg(
+                            metric, "totalShots", stats_t[player], stats_ct[player]
+                        ),
+                        abs_tol=0.11,
+                    )
+
+    def test_player_stats_suicide(self):
+        """Tests that player stats parses suicides correctly"""
+
+        test_rounds = [
+            {
+                "roundNum": 1,
+                "isWarmup": False,
+                "startTick": 17374,
+                "freezeTimeEndTick": 18898,
+                "endTick": 26021,
+                "endOfficialTick": 26910,
+                "bombPlantTick": 22924,
+                "tScore": 0,
+                "ctScore": 0,
+                "endTScore": 1,
+                "endCTScore": 0,
+                "ctTeam": "team_-Fuchshenger",
+                "tTeam": "team_Sunk3r",
+                "winningSide": "T",
+                "winningTeam": "team_Sunk3r",
+                "losingTeam": "team_-Fuchshenger",
+                "roundEndReason": "TerroristsWin",
+                "ctFreezeTimeEndEqVal": 3850,
+                "ctRoundStartEqVal": 1000,
+                "ctRoundSpendMoney": 3500,
+                "ctBuyType": "Full Eco",
+                "tFreezeTimeEndEqVal": 4250,
+                "tRoundStartEqVal": 1000,
+                "tRoundSpendMoney": 3250,
+                "tBuyType": "Full Eco",
+                "ctSide": {
+                    "teamName": "team_-Fuchshenger",
+                    "players": [
+                        {"playerName": "-Fuchshenger", "steamID": 76561199002916187},
+                        {"playerName": "MAKARxJESUS", "steamID": 76561198144899828},
+                        {"playerName": "XCSy", "steamID": 76561198366282668},
+                        {"playerName": "__NIKI_", "steamID": 76561198318595189},
+                        {"playerName": "Flubykiller", "steamID": 76561198118383015},
+                    ],
+                },
+                "tSide": {
+                    "teamName": "team_Sunk3r",
+                    "players": [
+                        {"playerName": "Sunk3r", "steamID": 76561198173639909},
+                        {"playerName": "SlaynThemAll", "steamID": 76561198156162722},
+                        {"playerName": "Afflic", "steamID": 76561198256616745},
+                        {"playerName": "yngtired", "steamID": 76561198853008998},
+                        {"playerName": "JanEric1", "steamID": 76561198049899734},
+                    ],
+                },
+                "kills": [
+                    {
+                        "tick": 21548,
+                        "seconds": 20.866141732283463,
+                        "clockTime": "01:35",
+                        "attackerSteamID": 76561198049899734,
+                        "attackerName": "JanEric1",
+                        "attackerTeam": "team_Sunk3r",
+                        "attackerSide": "T",
+                        "attackerX": 1623.4302978515625,
+                        "attackerY": 1222.76708984375,
+                        "attackerZ": 161.6575927734375,
+                        "attackerViewX": 337.1978759765625,
+                        "attackerViewY": 0.274658203125,
+                        "victimSteamID": 76561198049899734,
+                        "victimName": "JanEric1",
+                        "victimTeam": "team_Sunk3r",
+                        "victimSide": "T",
+                        "victimX": 1623.4302978515625,
+                        "victimY": 1222.76708984375,
+                        "victimZ": 161.6575927734375,
+                        "victimViewX": 337.1978759765625,
+                        "victimViewY": 0.274658203125,
+                        "assisterSteamID": 76561198173639909,
+                        "assisterName": "Sunk3r",
+                        "assisterTeam": "team_Sunk3r",
+                        "assisterSide": "T",
+                        "isSuicide": True,
+                        "isTeamkill": False,
+                        "isWallbang": False,
+                        "penetratedObjects": 0,
+                        "isFirstKill": True,
+                        "isHeadshot": True,
+                        "victimBlinded": False,
+                        "attackerBlinded": False,
+                        "flashThrowerSteamID": None,
+                        "flashThrowerName": None,
+                        "flashThrowerTeam": None,
+                        "flashThrowerSide": None,
+                        "noScope": False,
+                        "thruSmoke": False,
+                        "distance": 714.3147783842128,
+                        "isTrade": False,
+                        "playerTradedName": None,
+                        "playerTradedTeam": None,
+                        "playerTradedSteamID": None,
+                        "weapon": "Glock-18",
+                        "weaponClass": "Pistols",
+                    },
+                ],
+                "damages": [],
+                "weaponFires": [],
+                "flashes": [],
+                "grenades": [],
+                "bombEvents": [],
+            }
+        ]
+        stats = player_stats(test_rounds)
+        assert stats["76561198049899734"]["suicides"] == 1
+
+    def test_player_stats_none_player_before_clutch(self):
+        """Tests that player stats handles a side being None correctly in clutche initialization"""
+        test_rounds = [
+            {
+                "roundNum": 1,
+                "isWarmup": False,
+                "startTick": 17374,
+                "freezeTimeEndTick": 18898,
+                "endTick": 26021,
+                "endOfficialTick": 26910,
+                "bombPlantTick": 22924,
+                "tScore": 0,
+                "ctScore": 0,
+                "endTScore": 1,
+                "endCTScore": 0,
+                "ctTeam": "team_-Fuchshenger",
+                "tTeam": "team_Sunk3r",
+                "winningSide": "T",
+                "winningTeam": "team_Sunk3r",
+                "losingTeam": "team_-Fuchshenger",
+                "roundEndReason": "TerroristsWin",
+                "ctFreezeTimeEndEqVal": 3850,
+                "ctRoundStartEqVal": 1000,
+                "ctRoundSpendMoney": 3500,
+                "ctBuyType": "Full Eco",
+                "tFreezeTimeEndEqVal": 4250,
+                "tRoundStartEqVal": 1000,
+                "tRoundSpendMoney": 3250,
+                "tBuyType": "Full Eco",
+                "ctSide": {
+                    "teamName": "team_-Fuchshenger",
+                    "players": None,
+                },
+                "tSide": {
+                    "teamName": "team_Sunk3r",
+                    "players": None,
+                },
+                "kills": [
+                    {
+                        "tick": 21548,
+                        "seconds": 20.866141732283463,
+                        "clockTime": "01:35",
+                        "attackerSteamID": 76561198049899734,
+                        "attackerName": "JanEric1",
+                        "attackerTeam": "team_Sunk3r",
+                        "attackerSide": "T",
+                        "attackerX": 1623.4302978515625,
+                        "attackerY": 1222.76708984375,
+                        "attackerZ": 161.6575927734375,
+                        "attackerViewX": 337.1978759765625,
+                        "attackerViewY": 0.274658203125,
+                        "victimSteamID": 76561198118383015,
+                        "victimName": "Flubykiller",
+                        "victimTeam": "team_Sunk3r",
+                        "victimSide": "CT",
+                        "victimX": 1623.4302978515625,
+                        "victimY": 1222.76708984375,
+                        "victimZ": 161.6575927734375,
+                        "victimViewX": 337.1978759765625,
+                        "victimViewY": 0.274658203125,
+                        "assisterSteamID": 76561198173639909,
+                        "assisterName": "Sunk3r",
+                        "assisterTeam": "team_Sunk3r",
+                        "assisterSide": "T",
+                        "isSuicide": True,
+                        "isTeamkill": False,
+                        "isWallbang": False,
+                        "penetratedObjects": 0,
+                        "isFirstKill": True,
+                        "isHeadshot": True,
+                        "victimBlinded": False,
+                        "attackerBlinded": False,
+                        "flashThrowerSteamID": None,
+                        "flashThrowerName": None,
+                        "flashThrowerTeam": None,
+                        "flashThrowerSide": None,
+                        "noScope": False,
+                        "thruSmoke": False,
+                        "distance": 714.3147783842128,
+                        "isTrade": False,
+                        "playerTradedName": None,
+                        "playerTradedTeam": None,
+                        "playerTradedSteamID": None,
+                        "weapon": "Glock-18",
+                        "weaponClass": "Pistols",
+                    },
+                ],
+                "damages": [],
+                "weaponFires": [],
+                "flashes": [],
+                "grenades": [],
+                "bombEvents": [],
+            }
+        ]
+        player_stats(test_rounds)
+
+
+    def test_player_stats_none_player_in_clutch(self):
+        """Tests that player stats handles a side being None correctly in clutches"""
+        test_rounds = [
+            {
+                "roundNum": 1,
+                "isWarmup": False,
+                "startTick": 17374,
+                "freezeTimeEndTick": 18898,
+                "endTick": 26021,
+                "endOfficialTick": 26910,
+                "bombPlantTick": 22924,
+                "tScore": 0,
+                "ctScore": 0,
+                "endTScore": 1,
+                "endCTScore": 0,
+                "ctTeam": "team_-Fuchshenger",
+                "tTeam": "team_Sunk3r",
+                "winningSide": "T",
+                "winningTeam": "team_Sunk3r",
+                "losingTeam": "team_-Fuchshenger",
+                "roundEndReason": "TerroristsWin",
+                "ctFreezeTimeEndEqVal": 3850,
+                "ctRoundStartEqVal": 1000,
+                "ctRoundSpendMoney": 3500,
+                "ctBuyType": "Full Eco",
+                "tFreezeTimeEndEqVal": 4250,
+                "tRoundStartEqVal": 1000,
+                "tRoundSpendMoney": 3250,
+                "tBuyType": "Full Eco",
+                "ctSide": {
+                    "teamName": "team_-Fuchshenger",
+                    "players": [
+                        {"playerName": "-Fuchshenger", "steamID": 76561199002916187},
+                        {"playerName": "Flubykiller", "steamID": 76561198118383015},
+                    ],
+                },
+                "tSide": {
+                    "teamName": "team_Sunk3r",
+                    "players": None,
+                },
+                "kills": [
+                    {
+                        "tick": 21548,
+                        "seconds": 20.866141732283463,
+                        "clockTime": "01:35",
+                        "attackerSteamID": 76561198049899734,
+                        "attackerName": "JanEric1",
+                        "attackerTeam": "team_Sunk3r",
+                        "attackerSide": "T",
+                        "attackerX": 1623.4302978515625,
+                        "attackerY": 1222.76708984375,
+                        "attackerZ": 161.6575927734375,
+                        "attackerViewX": 337.1978759765625,
+                        "attackerViewY": 0.274658203125,
+                        "victimSteamID": 76561198118383015,
+                        "victimName": "Flubykiller",
+                        "victimTeam": "team_Sunk3r",
+                        "victimSide": "CT",
+                        "victimX": 1623.4302978515625,
+                        "victimY": 1222.76708984375,
+                        "victimZ": 161.6575927734375,
+                        "victimViewX": 337.1978759765625,
+                        "victimViewY": 0.274658203125,
+                        "assisterSteamID": 76561198173639909,
+                        "assisterName": "Sunk3r",
+                        "assisterTeam": "team_Sunk3r",
+                        "assisterSide": "T",
+                        "isSuicide": True,
+                        "isTeamkill": False,
+                        "isWallbang": False,
+                        "penetratedObjects": 0,
+                        "isFirstKill": True,
+                        "isHeadshot": True,
+                        "victimBlinded": False,
+                        "attackerBlinded": False,
+                        "flashThrowerSteamID": None,
+                        "flashThrowerName": None,
+                        "flashThrowerTeam": None,
+                        "flashThrowerSide": None,
+                        "noScope": False,
+                        "thruSmoke": False,
+                        "distance": 714.3147783842128,
+                        "isTrade": False,
+                        "playerTradedName": None,
+                        "playerTradedTeam": None,
+                        "playerTradedSteamID": None,
+                        "weapon": "Glock-18",
+                        "weaponClass": "Pistols",
+                    },
+                ],
+                "damages": [],
+                "weaponFires": [],
+                "flashes": [],
+                "grenades": [],
+                "bombEvents": [],
+            }
+        ]
+        player_stats(test_rounds)


### PR DESCRIPTION
Issue noted on discord for maps from Snow Sweet Snow events like these: https://www.hltv.org/matches/2346098/pompa-vs-honoris-snow-sweet-snow-1-regionals

Error: Line 196 `object of type 'NoneType' has no len()`

![image](https://user-images.githubusercontent.com/47750513/219963836-43a21564-2463-41ab-ae64-f67c0d881e14.png)
