### PR TITLE
Fix missing player

### DIFF
--- a/awpy/analytics/stats.py
+++ b/awpy/analytics/stats.py
@@ -23,6 +23,7 @@ from typing import Union, cast, Literal, Optional
 import pandas as pd
 from awpy.types import GameRound, PlayerStatistics
 
+
 # accuracy
 # kast
 # adr
@@ -73,10 +74,12 @@ def player_stats(
         # Add players
         kast: dict[str, dict[str, bool]] = {}
         round_kills = {}
+        active_players = set()
         for side in [team.lower() + "Side" for team in active_sides]:
             side = cast(Literal["ctSide", "tSide"], side)
             for p in r[side]["players"] or []:
                 player_key = p["playerName"] if p["steamID"] == 0 else str(p["steamID"])
+                active_players.add(player_key)
                 if player_key not in player_statistics:
                     player_statistics[player_key] = {
                         "steamID": p["steamID"],
@@ -134,12 +137,13 @@ def player_stats(
                         "success1v5": 0,
                     }
                 player_statistics[player_key]["totalRounds"] += 1
-                kast[player_key] = {}
-                kast[player_key]["k"] = False
-                kast[player_key]["a"] = False
-                kast[player_key]["s"] = True
-                kast[player_key]["t"] = False
-                round_kills[player_key] = 0
+        for player_key in active_players:
+            kast[player_key] = {}
+            kast[player_key]["k"] = False
+            kast[player_key]["a"] = False
+            kast[player_key]["s"] = True
+            kast[player_key]["t"] = False
+            round_kills[player_key] = 0
         # Calculate kills
         players_killed: dict[Literal["CT", "T"], set[str]] = {
             "T": set(),
@@ -147,34 +151,16 @@ def player_stats(
         }
         is_clutching: set[Optional[str]] = set()
         for k in r["kills"] or []:
-            killer_key = (
-                str(k["attackerName"])
-                if str(k["attackerSteamID"]) == 0
-                else str(k["attackerSteamID"])
-            )
-            victim_key = (
-                str(k["victimName"])
-                if str(k["victimSteamID"]) == 0
-                else str(k["victimSteamID"])
-            )
-            assister_key = (
-                str(k["assisterName"])
-                if str(k["assisterSteamID"]) == 0
-                else str(k["assisterSteamID"])
-            )
+            killer_key = str(k["attackerName"]) if str(k["attackerSteamID"]) == 0 else str(k["attackerSteamID"])
+            victim_key = str(k["victimName"]) if str(k["victimSteamID"]) == 0 else str(k["victimSteamID"])
+            assister_key = str(k["assisterName"]) if str(k["assisterSteamID"]) == 0 else str(k["assisterSteamID"])
             flashthrower_key = (
-                str(k["flashThrowerName"])
-                if str(k["flashThrowerSteamID"]) == 0
-                else str(k["flashThrowerSteamID"])
+                str(k["flashThrowerName"]) if str(k["flashThrowerSteamID"]) == 0 else str(k["flashThrowerSteamID"])
             )
             if k["victimSide"] in players_killed:
                 players_killed[k["victimSide"]].add(victim_key)  # type: ignore[index]
             # Purely attacker related stats
-            if (
-                k["attackerSide"] in active_sides
-                and killer_key in player_statistics
-                and k["attackerSteamID"]
-            ):
+            if killer_key in active_players and k["attackerSteamID"]:
                 if not k["isSuicide"] and not k["isTeamkill"]:
                     player_statistics[killer_key]["kills"] += 1
                     round_kills[killer_key] += 1
@@ -184,7 +170,7 @@ def player_stats(
                 if k["isHeadshot"]:
                     player_statistics[killer_key]["hs"] += 1
             # Purely victim related stats:
-            if victim_key in player_statistics and k["victimSide"] in active_sides:
+            if victim_key in active_players:
                 player_statistics[victim_key]["deaths"] += 1
                 kast[victim_key]["s"] = False
                 if k["isSuicide"]:
@@ -198,15 +184,11 @@ def player_stats(
                 == 1
             ):
                 for player in r[k["victimSide"].lower() + "Side"]["players"]:  # type: ignore[literal-required]
-                    clutcher_key = (
-                        str(player["playermName"])
-                        if str(player["steamID"]) == 0
-                        else str(player["steamID"])
-                    )
+                    clutcher_key = str(player["playermName"]) if str(player["steamID"]) == 0 else str(player["steamID"])
                     if (
                         clutcher_key not in players_killed[k["victimSide"]]  # type: ignore[literal-required, index]
                         and clutcher_key not in is_clutching
-                        and clutcher_key in player_statistics
+                        and clutcher_key in active_players
                     ):
                         is_clutching.add(clutcher_key)
                         enemies_alive = len(
@@ -228,12 +210,7 @@ def player_stats(
                 # -> that is not a trade kill for you
                 # If you kill someone and then yourself
                 # -> that is not a trade kill for you
-                if (
-                    k["attackerSide"] != k["victimSide"]
-                    and k["attackerSide"] in active_sides
-                    and killer_key in player_statistics
-                    and k["attackerSteamID"]
-                ):
+                if k["attackerSide"] != k["victimSide"] and killer_key in active_players and k["attackerSteamID"]:
                     player_statistics[killer_key]["tradeKills"] += 1
                 # Enemies CAN trade your own death
                 # If you force an enemy to teamkill their mate after your death
@@ -241,19 +218,13 @@ def player_stats(
                 # If you force your killer to kill themselves (in their own molo/nade/fall)
                 # -> that is a traded death for you
                 traded_key = (
-                    k["playerTradedName"]
-                    if str(k["playerTradedSteamID"]) == 0
-                    else str(k["playerTradedSteamID"])
+                    k["playerTradedName"] if str(k["playerTradedSteamID"]) == 0 else str(k["playerTradedSteamID"])
                 )
                 # In most cases the traded player is on the same team as the trader
                 # However in the above scenarios the opposite can be the case
                 # So it is not enough to know that the trading player and
                 # their side is initialized
-                if (
-                    k["playerTradedSide"] in active_sides
-                    and traded_key in player_statistics
-                    and k["playerTradedSteamID"]
-                ):
+                if traded_key in active_players and k["playerTradedSteamID"]:
                     kast[traded_key]["t"] = True
                     player_statistics[traded_key]["tradedDeaths"] += 1
             if (
@@ -267,81 +238,41 @@ def player_stats(
             if (
                 k["flashThrowerSteamID"]
                 and k["flashThrowerSide"] != k["victimSide"]
-                and flashthrower_key in player_statistics
-                and k["flashThrowerSide"] in active_sides
+                and flashthrower_key in active_players
             ):
                 player_statistics[flashthrower_key]["flashAssists"] += 1
                 kast[flashthrower_key]["a"] = True
 
             if k["isFirstKill"] and k["attackerSteamID"]:
-                if (
-                    k["attackerSide"] in active_sides
-                    and killer_key in player_statistics
-                ):
+                if killer_key in active_players:
                     player_statistics[killer_key]["firstKills"] += 1
-                if k["victimSide"] in active_sides and victim_key in player_statistics:
+                if victim_key in active_players:
                     player_statistics[victim_key]["firstDeaths"] += 1
 
         for d in r["damages"] or []:
-            attacker_key = (
-                str(d["attackerName"])
-                if str(d["attackerSteamID"]) == 0
-                else str(d["attackerSteamID"])
-            )
-            victim_key = (
-                str(d["victimName"])
-                if str(d["victimSteamID"]) == 0
-                else str(d["victimSteamID"])
-            )
+            attacker_key = str(d["attackerName"]) if str(d["attackerSteamID"]) == 0 else str(d["attackerSteamID"])
+            victim_key = str(d["victimName"]) if str(d["victimSteamID"]) == 0 else str(d["victimSteamID"])
             # Purely attacker related stats
-            if (
-                d["attackerSide"] in active_sides
-                and attacker_key in player_statistics
-                and d["attackerSteamID"]
-            ):
+            if attacker_key in active_players and d["attackerSteamID"]:
                 if not d["isFriendlyFire"]:
-                    player_statistics[attacker_key]["totalDamageGiven"] += d[
-                        "hpDamageTaken"
-                    ]
+                    player_statistics[attacker_key]["totalDamageGiven"] += d["hpDamageTaken"]
                 else:  # d["isFriendlyFire"]:
-                    player_statistics[attacker_key]["totalTeamDamageGiven"] += d[
-                        "hpDamageTaken"
-                    ]
+                    player_statistics[attacker_key]["totalTeamDamageGiven"] += d["hpDamageTaken"]
                 if d["weaponClass"] not in ["Unknown", "Grenade", "Equipment"]:
                     player_statistics[attacker_key]["shotsHit"] += 1
                 if d["weaponClass"] == "Grenade":
-                    player_statistics[attacker_key]["utilityDamage"] += d[
-                        "hpDamageTaken"
-                    ]
-            if (
-                d["victimSteamID"]
-                and victim_key in player_statistics
-                and d["victimSide"] in active_sides
-            ):
+                    player_statistics[attacker_key]["utilityDamage"] += d["hpDamageTaken"]
+            if d["victimSteamID"] and victim_key in active_players:
                 player_statistics[victim_key]["totalDamageTaken"] += d["hpDamageTaken"]
 
         for w in r["weaponFires"] or []:
-            fire_key = (
-                w["playerName"] if w["playerSteamID"] == 0 else str(w["playerSteamID"])
-            )
-            if fire_key in player_statistics and w["playerSide"] in active_sides:
+            fire_key = w["playerName"] if w["playerSteamID"] == 0 else str(w["playerSteamID"])
+            if fire_key in active_players:
                 player_statistics[fire_key]["totalShots"] += 1
         for f in r["flashes"] or []:
-            flasher_key = (
-                str(f["attackerName"])
-                if str(f["attackerSteamID"]) == 0
-                else str(f["attackerSteamID"])
-            )
-            player_key = (
-                str(f["playerName"])
-                if str(f["playerSteamID"]) == 0
-                else str(f["playerSteamID"])
-            )
-            if (
-                f["attackerSteamID"]
-                and flasher_key in player_statistics
-                and f["attackerSide"] in active_sides
-            ):
+            flasher_key = str(f["attackerName"]) if str(f["attackerSteamID"]) == 0 else str(f["attackerSteamID"])
+            player_key = str(f["playerName"]) if str(f["playerSteamID"]) == 0 else str(f["playerSteamID"])
+            if f["attackerSteamID"] and flasher_key in active_players:
                 if f["attackerSide"] == f["playerSide"]:
                     player_statistics[flasher_key]["teammatesFlashed"] += 1
                 else:
@@ -350,16 +281,8 @@ def player_stats(
                         0 if f["flashDuration"] is None else f["flashDuration"]
                     )
         for g in r["grenades"] or []:
-            thrower_key = (
-                g["throwerName"]
-                if g["throwerSteamID"] == 0
-                else str(g["throwerSteamID"])
-            )
-            if (
-                g["throwerSteamID"]
-                and thrower_key in player_statistics
-                and g["throwerSide"] in active_sides
-            ):
+            thrower_key = g["throwerName"] if g["throwerSteamID"] == 0 else str(g["throwerSteamID"])
+            if g["throwerSteamID"] and thrower_key in active_players:
                 if g["grenadeType"] == "Smoke Grenade":
                     player_statistics[thrower_key]["smokesThrown"] += 1
                 if g["grenadeType"] == "Flashbang":
@@ -369,19 +292,17 @@ def player_stats(
                 if g["grenadeType"] in ["Incendiary Grenade", "Molotov"]:
                     player_statistics[thrower_key]["fireThrown"] += 1
         for b in r["bombEvents"] or []:
-            player_key = (
-                b["playerName"] if b["playerSteamID"] == 0 else str(b["playerSteamID"])
-            )
-            if b["playerSteamID"] and player_key in player_statistics:
-                if b["bombAction"] == "plant" and "T" in active_sides:
+            player_key = b["playerName"] if b["playerSteamID"] == 0 else str(b["playerSteamID"])
+            if b["playerSteamID"] and player_key in active_players:
+                if b["bombAction"] == "plant":
                     player_statistics[player_key]["plants"] += 1
-                if b["bombAction"] == "defuse" and "CT" in active_sides:
+                if b["bombAction"] == "defuse":
                     player_statistics[player_key]["defuses"] += 1
         for player, components in kast.items():
-            if any(components.values()):
+            if player in active_players and any(components.values()):
                 player_statistics[player]["kast"] += 1
         for player, n_kills in round_kills.items():
-            if n_kills in range(6):  # 0, 1, 2, 3, 4, 5
+            if n_kills in range(6) and player in active_players:  # 0, 1, 2, 3, 4, 5
                 player_statistics[player][f"kills{n_kills}"] += 1  # type: ignore[literal-required]
 
     for player in player_statistics.values():
@@ -391,9 +312,7 @@ def player_stats(
         )
         player["blindTime"] = round(player["blindTime"], 2)
         player["kdr"] = round(
-            player["kills"] / player["deaths"]
-            if player["deaths"] != 0
-            else player["kills"],
+            player["kills"] / player["deaths"] if player["deaths"] != 0 else player["kills"],
             2,
         )
         player["adr"] = round(
@@ -401,9 +320,7 @@ def player_stats(
             1,
         )
         player["accuracy"] = round(
-            player["shotsHit"] / player["totalShots"]
-            if player["totalShots"] != 0
-            else 0,
+            player["shotsHit"] / player["totalShots"] if player["totalShots"] != 0 else 0,
             2,
         )
         player["hsPercent"] = round(
@@ -411,9 +328,7 @@ def player_stats(
             2,
         )
         impact = (
-            2.13 * (player["kills"] / player["totalRounds"])
-            + 0.42 * (player["assists"] / player["totalRounds"])
-            - 0.41
+            2.13 * (player["kills"] / player["totalRounds"]) + 0.42 * (player["assists"] / player["totalRounds"]) - 0.41
         )
         player["rating"] = (
             0.0073 * player["kast"]
@@ -426,10 +341,6 @@ def player_stats(
         player["rating"] = round(player["rating"], 2)
 
     if return_type == "df":
-        return (
-            pd.DataFrame()
-            .from_dict(player_statistics, orient="index")
-            .reset_index(drop=True)
-        )
+        return pd.DataFrame().from_dict(player_statistics, orient="index").reset_index(drop=True)
     else:
         return player_statistics

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -381,116 +381,6 @@ class TestStats:
         ]
         player_stats(test_rounds)
 
-    def test_player_stats_suicide(self):
-        """Tests that player stats parses suicides correctly"""
-
-        test_rounds = [
-            {
-                "roundNum": 1,
-                "isWarmup": False,
-                "startTick": 17374,
-                "freezeTimeEndTick": 18898,
-                "endTick": 26021,
-                "endOfficialTick": 26910,
-                "bombPlantTick": 22924,
-                "tScore": 0,
-                "ctScore": 0,
-                "endTScore": 1,
-                "endCTScore": 0,
-                "ctTeam": "team_-Fuchshenger",
-                "tTeam": "team_Sunk3r",
-                "winningSide": "T",
-                "winningTeam": "team_Sunk3r",
-                "losingTeam": "team_-Fuchshenger",
-                "roundEndReason": "TerroristsWin",
-                "ctFreezeTimeEndEqVal": 3850,
-                "ctRoundStartEqVal": 1000,
-                "ctRoundSpendMoney": 3500,
-                "ctBuyType": "Full Eco",
-                "tFreezeTimeEndEqVal": 4250,
-                "tRoundStartEqVal": 1000,
-                "tRoundSpendMoney": 3250,
-                "tBuyType": "Full Eco",
-                "ctSide": {
-                    "teamName": "team_-Fuchshenger",
-                    "players": [
-                        {"playerName": "-Fuchshenger", "steamID": 76561199002916187},
-                        {"playerName": "MAKARxJESUS", "steamID": 76561198144899828},
-                        {"playerName": "XCSy", "steamID": 76561198366282668},
-                        {"playerName": "__NIKI_", "steamID": 76561198318595189},
-                        {"playerName": "Flubykiller", "steamID": 76561198118383015},
-                    ],
-                },
-                "tSide": {
-                    "teamName": "team_Sunk3r",
-                    "players": [
-                        {"playerName": "Sunk3r", "steamID": 76561198173639909},
-                        {"playerName": "SlaynThemAll", "steamID": 76561198156162722},
-                        {"playerName": "Afflic", "steamID": 76561198256616745},
-                        {"playerName": "yngtired", "steamID": 76561198853008998},
-                        {"playerName": "JanEric1", "steamID": 76561198049899734},
-                    ],
-                },
-                "kills": [
-                    {
-                        "tick": 21548,
-                        "seconds": 20.866141732283463,
-                        "clockTime": "01:35",
-                        "attackerSteamID": 76561198049899734,
-                        "attackerName": "JanEric1",
-                        "attackerTeam": "team_Sunk3r",
-                        "attackerSide": "T",
-                        "attackerX": 1623.4302978515625,
-                        "attackerY": 1222.76708984375,
-                        "attackerZ": 161.6575927734375,
-                        "attackerViewX": 337.1978759765625,
-                        "attackerViewY": 0.274658203125,
-                        "victimSteamID": 76561198049899734,
-                        "victimName": "JanEric1",
-                        "victimTeam": "team_Sunk3r",
-                        "victimSide": "T",
-                        "victimX": 1623.4302978515625,
-                        "victimY": 1222.76708984375,
-                        "victimZ": 161.6575927734375,
-                        "victimViewX": 337.1978759765625,
-                        "victimViewY": 0.274658203125,
-                        "assisterSteamID": 76561198173639909,
-                        "assisterName": "Sunk3r",
-                        "assisterTeam": "team_Sunk3r",
-                        "assisterSide": "T",
-                        "isSuicide": True,
-                        "isTeamkill": False,
-                        "isWallbang": False,
-                        "penetratedObjects": 0,
-                        "isFirstKill": True,
-                        "isHeadshot": True,
-                        "victimBlinded": False,
-                        "attackerBlinded": False,
-                        "flashThrowerSteamID": None,
-                        "flashThrowerName": None,
-                        "flashThrowerTeam": None,
-                        "flashThrowerSide": None,
-                        "noScope": False,
-                        "thruSmoke": False,
-                        "distance": 714.3147783842128,
-                        "isTrade": False,
-                        "playerTradedName": None,
-                        "playerTradedTeam": None,
-                        "playerTradedSteamID": None,
-                        "weapon": "Glock-18",
-                        "weaponClass": "Pistols",
-                    },
-                ],
-                "damages": [],
-                "weaponFires": [],
-                "flashes": [],
-                "grenades": [],
-                "bombEvents": [],
-            }
-        ]
-        stats = player_stats(test_rounds)
-        assert stats["76561198049899734"]["suicides"] == 1
-
     def test_player_stats_none_player_before_clutch(self):
         """Tests that player stats handles a side being None correctly in clutche initialization"""
         test_rounds = [
@@ -586,7 +476,6 @@ class TestStats:
             }
         ]
         player_stats(test_rounds)
-
 
     def test_player_stats_none_player_in_clutch(self):
         """Tests that player stats handles a side being None correctly in clutches"""


### PR DESCRIPTION
Added a fix for an issue reported on discord by "RunGuitarMan" that caused crashes in the stat module when a player timed out at the start of the round and thus did not appear in the list of players but caused an entry for killing himself.