### PR TITLE
Adding per round frameID entry to GameFrames.

### DIFF
--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -898,7 +898,7 @@ class DemoParser:
 
         Raises:
             AttributeError: Raises an AttributeError if the .json attribute
-                has a "gameRounds" key.
+                has no "gameRounds" key.
         """
         if self.json and self.json["gameRounds"]:
             for i, _r in enumerate(self.json["gameRounds"]):

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -869,6 +869,7 @@ class DemoParser:
             if remove_bad_scoring:
                 self.remove_bad_scoring()
             self.renumber_rounds()
+            self.renumber_frames()
             # self.rescore_rounds() -- Need to edit to take into account half switches
             if save_to_json:
                 self.write_json()
@@ -903,6 +904,30 @@ class DemoParser:
         if self.json and self.json["gameRounds"]:
             for i, _r in enumerate(self.json["gameRounds"]):
                 self.json["gameRounds"][i]["roundNum"] = i + 1
+        else:
+            self.logger.error(
+                "JSON not found. Run .parse() or .read_json() if JSON already exists"
+            )
+            raise AttributeError(
+                "JSON not found. Run .parse() or .read_json() if JSON already exists"
+            )
+
+    def renumber_frames(self) -> None:
+        """Renumbers the frames.
+
+        Needed since cleaning can remove frames and cause
+        some indices to be skipped.
+
+        Raises:
+            AttributeError: Raises an AttributeError if the .json attribute has no "gameRounds" key.
+        """
+        if self.json and self.json["gameRounds"]:
+            for index, frame in enumerate(
+                frame
+                for game_round in self.json["gameRounds"]
+                for frame in game_round["frames"] or []
+            ):
+                frame["globalFrameID"] = index
         else:
             self.logger.error(
                 "JSON not found. Run .parse() or .read_json() if JSON already exists"

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -919,7 +919,8 @@ class DemoParser:
         some indices to be skipped.
 
         Raises:
-            AttributeError: Raises an AttributeError if the .json attribute has no "gameRounds" key.
+            AttributeError: Raises an AttributeError if the .json attribute
+                has no "gameRounds" key.
         """
         if self.json and self.json["gameRounds"]:
             for index, frame in enumerate(

--- a/awpy/parser/parse_demo.go
+++ b/awpy/parser/parse_demo.go
@@ -334,6 +334,7 @@ type FlashAction struct {
 
 // GameFrame (game state at time t)
 type GameFrame struct {
+	FrameID     int64         `json:"frameID"`
 	IsKillFrame bool          `json:"isKillFrame"`
 	Tick        int64         `json:"tick"`
 	Second      float64       `json:"seconds"`
@@ -879,6 +880,11 @@ func cleanMapName(mapName string) string {
 func removeExpiredSmoke(s []Smoke, i int) []Smoke {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
+}
+
+func appendFrameToRound(currentRound *GameRound, currentFrame *GameFrame) {
+	currentFrame.FrameID = int64(len(currentRound.Frames))
+	currentRound.Frames = append(currentRound.Frames, *currentFrame)
 }
 
 // Main
@@ -2070,8 +2076,7 @@ func main() {
 			} else {
 				currentFrame.BombPlanted = false
 			}
-
-			currentRound.Frames = append(currentRound.Frames, currentFrame)
+			appendFrameToRound(&currentRound, &currentFrame)
 		}
 
 		currentKill := KillAction{}
@@ -2512,10 +2517,10 @@ func main() {
 			if (len(currentFrame.CT.Players) > 0) || (len(currentFrame.T.Players) > 0) {
 				if len(currentRound.Frames) > 0 {
 					if currentRound.Frames[len(currentRound.Frames)-1].Tick < currentFrame.Tick {
-						currentRound.Frames = append(currentRound.Frames, currentFrame)
+						appendFrameToRound(&currentRound, &currentFrame)
 					}
 				} else {
-					currentRound.Frames = append(currentRound.Frames, currentFrame)
+					appendFrameToRound(&currentRound, &currentFrame)
 				}
 			}
 

--- a/awpy/types.py
+++ b/awpy/types.py
@@ -492,6 +492,7 @@ class GameFrame(TypedDict):
     """GameFrame (game state at time t)."""
 
     frameId: int
+    globalFrameID: int
     isKillFrame: bool
     tick: int
     seconds: float

--- a/awpy/types.py
+++ b/awpy/types.py
@@ -491,6 +491,7 @@ class Smoke(TypedDict):
 class GameFrame(TypedDict):
     """GameFrame (game state at time t)."""
 
+    frameId: int
     isKillFrame: bool
     tick: int
     seconds: float

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -571,10 +571,19 @@ class TestDemoParser:
         Every round has frames with ids going from 0
         to len(round["frames])-1"""
         self.index_parser = DemoParser(
-            demofile="vitality-vs-g2-m2-mirage.dem", log=False, parse_frames=True
+            demofile="vitality-vs-g2-m2-mirage.dem",
+            log=False,
+            parse_frames=True,
         )
-        self.index_parser.parse()
+        self.index_parser.parse(clean=False)
         for game_round in self.index_parser.json["gameRounds"]:
             assert [frame["frameID"] for frame in game_round["frames"]] == list(
                 range(len(game_round["frames"]))
             )
+
+        for index, frame in enumerate(
+            frame
+            for game_round in self.index_parser.json["gameRounds"]
+            for frame in game_round["frames"]
+        ):
+            assert index == frame["globalFrameID"]

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -569,7 +569,8 @@ class TestDemoParser:
         """Tests that frame indices work as expected.
 
         Every round has frames with ids going from 0
-        to len(round["frames])-1"""
+        to len(round["frames])-1
+        """
         self.index_parser = DemoParser(
             demofile="vitality-vs-g2-m2-mirage.dem",
             log=False,
@@ -607,13 +608,14 @@ class TestDemoParser:
             for game_round in self.renumbering_parser.json["gameRounds"]
         ] != list(range(len(self.renumbering_parser.json["gameRounds"])))
 
-        with pytest.raises(AssertionError, match="globalFrameID off somewhere"):
-            for index, frame in enumerate(
-                frame
-                for game_round in self.renumbering_parser.json["gameRounds"]
-                for frame in game_round["frames"]
-            ):
+        for index, frame in enumerate(
+            frame
+            for game_round in self.renumbering_parser.json["gameRounds"]
+            for frame in game_round["frames"]
+        ):
+            with pytest.raises(AssertionError, match="globalFrameID off somewhere"):
                 assert index == frame["globalFrameID"], "globalFrameID off somewhere"
+
         self.renumbering_parser.renumber_rounds()
         self.renumbering_parser.renumber_frames()
         assert [

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -587,3 +587,43 @@ class TestDemoParser:
             for frame in game_round["frames"]
         ):
             assert index == frame["globalFrameID"]
+
+    def test_renumbering(self):
+        """Tests that renumbering rounds and frames works."""
+        self.renumbering_parser = DemoParser(
+            demofile="esea_match_16902209.dem", log=False, parse_frames=True
+        )
+        self.round_clean_data = self.renumbering_parser.parse(clean=False)
+        self.renumbering_parser.remove_rounds_with_no_frames()
+        self.renumbering_parser.remove_warmups()
+        self.renumbering_parser.remove_knife_rounds()
+        self.renumbering_parser.remove_time_rounds()
+        self.renumbering_parser.remove_excess_players()
+        self.renumbering_parser.remove_excess_kill_rounds()
+        self.renumbering_parser.remove_end_round()
+        self.renumbering_parser.remove_bad_scoring()
+        assert [
+            game_round["roundNum"] - 1
+            for game_round in self.renumbering_parser.json["gameRounds"]
+        ] != list(range(len(self.renumbering_parser.json["gameRounds"])))
+
+        with pytest.raises(AssertionError, match="globalFrameID off somewhere"):
+            for index, frame in enumerate(
+                frame
+                for game_round in self.renumbering_parser.json["gameRounds"]
+                for frame in game_round["frames"]
+            ):
+                assert index == frame["globalFrameID"], "globalFrameID off somewhere"
+        self.renumbering_parser.renumber_rounds()
+        self.renumbering_parser.renumber_frames()
+        assert [
+            game_round["roundNum"] - 1
+            for game_round in self.renumbering_parser.json["gameRounds"]
+        ] == list(range(len(self.renumbering_parser.json["gameRounds"])))
+
+        for index, frame in enumerate(
+            frame
+            for game_round in self.renumbering_parser.json["gameRounds"]
+            for frame in game_round["frames"]
+        ):
+            assert index == frame["globalFrameID"]

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -564,3 +564,17 @@ class TestDemoParser:
         no_json_parser.json = {"gameRounds": None}
         with pytest.raises(AttributeError):
             no_json_parser.renumber_rounds()
+
+    def test_frame_indices(self):
+        """Tests that frame indices work as expected.
+
+        Every round has frames with ids going from 0
+        to len(round["frames])-1"""
+        self.index_parser = DemoParser(
+            demofile="vitality-vs-g2-m2-mirage.dem", log=False, parse_frames=True
+        )
+        self.index_parser.parse()
+        for game_round in self.index_parser.json["gameRounds"]:
+            assert [frame["frameID"] for frame in game_round["frames"]] == list(
+                range(len(game_round["frames"]))
+            )


### PR DESCRIPTION
Adding `frameID` key to each GameFrame that contains the index of the frame in its round. Addresses: https://github.com/pnxenopoulos/awpy/issues/193

This means that 

`[frame["frameID"] for frame in game_round["frames"]] == list(range(len(game_round["frames"])))`

or 

```
for index, frame in enumerate(game_round["frames"]):
    index == frame["frameId"]
```

I dont know if a "global" frameID would also be interesting. That would be a tiny bit harder to implement.