### PR TITLE
Added pydantic check to setting of parser json. Updated requirements.

### DIFF
--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -214,21 +214,21 @@ class DemoParser:
         return self._json
 
     @json.setter
-    def json(self, json: Game | None) -> None:
+    def json(self, new_json: Game | None) -> None:
         """Validate json shape via pydantic.
 
         Args:
-            json (Game | None): Game dict to use.
+            new_json (Game | None): Game dict to use.
         """
-        if json is not None:
+        if new_json is not None:
             try:
-                TypeAdapter(Game).validate_python(json)
+                TypeAdapter(Game).validate_python(new_json)
             except ValidationError:
                 self.logger.exception(
                     "Loaded json file does not have correct fields."
                     " This may cause issues later."
                 )
-        self._json = json
+        self._json = new_json
 
     @property
     def buy_style(self) -> BuyStyle:

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal, Unpack, get_args, overload
 
 import pandas as pd
+from pydantic import TypeAdapter, ValidationError
 
 from awpy.types import (
     BuyStyle,
@@ -188,7 +189,7 @@ class DemoParser:
         self.parse_error = False
 
         # Initialize json attribute as None
-        self.json: Game | None = None
+        self._json: Game | None = None
 
     def log_settings(self) -> None:
         """Log the settings produced in the cosntructor."""
@@ -202,6 +203,32 @@ class DemoParser:
         )
         self.logger.info("Setting trade time to %d", self.trade_time)
         self.logger.info("Setting buy style to %s", str(self.buy_style))
+
+    @property
+    def json(self) -> Game | None:
+        """Json getter.
+
+        Returns:
+            Game: Parsed demo information in json format
+        """
+        return self._json
+
+    @json.setter
+    def json(self, json: Game | None) -> None:
+        """Validate json shape via pydantic.
+
+        Args:
+            json (Game | None): Game dict to use.
+        """
+        if json is not None:
+            try:
+                TypeAdapter(Game).validate_python(json)
+            except ValidationError:
+                self.logger.exception(
+                    "Loaded json file does not have correct fields."
+                    " This may cause issues later."
+                )
+        self._json = json
 
     @property
     def buy_style(self) -> BuyStyle:

--- a/awpy/types.py
+++ b/awpy/types.py
@@ -1,7 +1,9 @@
 """This module contains the type definitions for the parsed json structure."""
 
 from dataclasses import dataclass
-from typing import Literal, NotRequired, TypedDict, TypeGuard, final, overload
+from typing import Literal, NotRequired, TypeGuard, final, overload
+
+from typing_extensions import TypedDict  # noqa: UP035
 
 
 @dataclass
@@ -461,17 +463,17 @@ class PlayerInfo(TypedDict):
     isBot: bool
     isBlinded: bool
     isAirborne: bool
-    isDuck: bool
-    isDuckInProgress: bool
-    isUnDuckInProgress: bool
-    isDefus: bool
-    isPlant: bool
-    isReload: bool
+    isDucking: bool
+    isDuckingInProgress: bool
+    isUnDuckingInProgress: bool
+    isDefusing: bool
+    isPlanting: bool
+    isReloading: bool
     isInBombZone: bool
     isInBuyZone: bool
-    isStand: bool
+    isStanding: bool
     isScoped: bool
-    isWalk: bool
+    isWalking: bool
     isUnknown: bool
     inventory: list[WeaponInfo] | None
     spotters: list[int] | None
@@ -484,7 +486,7 @@ class PlayerInfo(TypedDict):
     hasHelmet: bool
     hasDefuse: bool
     hasBomb: bool
-    p: int
+    ping: int
     zoomLevel: int
 
 
@@ -512,7 +514,7 @@ class Smoke(TypedDict):
 class GameFrame(TypedDict):
     """GameFrame (game state at time t)."""
 
-    frameId: int
+    frameID: int
     globalFrameID: int
     isKillFrame: bool
     tick: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,19 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "imageio==2.28",
-    "matplotlib==3.7",
-    "networkx==2.6",
+    "imageio~=2.28.0",
+    "matplotlib~=3.7.0",
+    "networkx~=3.1",
     "numpy>=1.20,<=1.25",
-    "pandas>=2.0.1, <=2.1",
-    "scipy==1.10",
-    "Shapely==2.0",
+    "pandas~=2.0.1",
+    "pydantic~=2.0.1",
+    "scipy~=1.10.0",
+    "Shapely~=2.0.0",
     "sphinx-rtd-theme==1.2",
     "sympy==1.11",
-    "textdistance==4.5",
-    "tqdm==4.55",
+    "textdistance~=4.5.0",
+    "tqdm~=4.65.0",
+    "typing_extensions~=4.7.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,9 @@ good-names = ["i", "j", "k", "ex", "Run", "_", "x", "y", "z", "e"]
 max-args = 15
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes = 7
+# One more than the standard 7 because it double counts
+# the json attribute that is just wrapped via the property.
+max-attributes = 8
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,13 @@
-imageio==2.28
-matplotlib==3.7
-networkx==2.6
+imageio~=2.28.0
+matplotlib~=3.7.0
+networkx~=3.1
 numpy>=1.20,<=1.25
-pandas>=2.0.1, <=2.1
-scipy==1.10
-Shapely==2.0
+pandas~=2.0.1
+pydantic~=2.0.1
+scipy~=1.10.0
+Shapely~=2.0.0
 sphinx-rtd-theme==1.2
 sympy==1.11
-textdistance==4.5
-tqdm==4.55
+textdistance~=4.5.0
+tqdm~=4.65.0
+typing_extensions~=4.7.0

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,19 @@ setup(
     # Project uses reStructuredText, so ensure that the docutils get
     # installed or upgraded on the target machine
     install_requires=[
-        "imageio==2.28",
-        "matplotlib==3.7",
-        "networkx==2.6",
+        "imageio~=2.28.0",
+        "matplotlib~=3.7.0",
+        "networkx~=3.1",
         "numpy>=1.20,<=1.25",
-        "pandas>=2.0.1, <=2.1",
-        "scipy==1.10",
-        "Shapely==2.0",
+        "pandas~=2.0.1",
+        "pydantic~=2.0.1",
+        "scipy~=1.10.0",
+        "Shapely~=2.0.0",
         "sphinx-rtd-theme==1.2",
         "sympy==1.11",
-        "textdistance==4.5",
-        "tqdm==4.55",
+        "textdistance~=4.5.0",
+        "tqdm~=4.65.0",
+        "typing_extensions~=4.7.0",
     ],
     package_data={
         # If any package contains *.txt or *.rst files, include them:


### PR DESCRIPTION
Added a check with pydantic that the loaded json conforms to the expected structure from the awpy.types module.

If the check fails a warning is emitted but the program continues.

Due to the check if fixed some typos in the definitions of the typed dicts.

At the moment usage of pydantic requires typeddict to be imported from typing_extensions.
So i have added that as a requirement and disabled the ruff warning that wants me to change it back.

Also updated/fixed some requirement specifications.