### PR TITLE
fixed versioning in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Peter Xenopoulos
+Copyright (c) 2020-2023 Peter Xenopoulos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1,4 +1,5 @@
 """This module defines the DemoParser class that handles the core functionality.
+
 Core functionality is parsing and cleaning a csgo demo file.
 
 Example::

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1,8 +1,8 @@
 """This module defines the DemoParser class that handles the core functionality.
-
-    Core functionality is parsing and cleaning a csgo demo file.
+Core functionality is parsing and cleaning a csgo demo file.
 
 Example::
+
     from awpy.parser import DemoParser
 
     # Create parser object
@@ -14,7 +14,6 @@ Example::
         trade_time=5,
         buy_style="hltv"
     )
-
 
     # Parse the demofile, output results to dictionary
     data = demo_parser.parse()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = "awpy"
-copyright = "2023    , Peter Xenopoulos"
+copyright = "2023, Peter Xenopoulos"
 author = "Peter Xenopoulos"
 
 # The short X.Y version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = "awpy"
-copyright = "2022, Peter Xenopoulos"
+copyright = "2023    , Peter Xenopoulos"
 author = "Peter Xenopoulos"
 
 # The short X.Y version

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ awpy
 .. |Licence| image:: https://img.shields.io/badge/license-MIT-lightgrey
    :target: https://github.com/pnxenopoulos/awpy/blob/main/LICENSE
    
-`awpy` allows a user to parse, analyze and visualize Counter-Strike: Global Offensive (CSGO) demo files. You can visit the repository_ to view the source code, examples and data. Please join the Discord_ server if you would like to join our esports analytics community or to receive help with the library. To install the library, run ``pip install awpy`` (Python >= 3.9).
+`awpy` allows a user to parse, analyze and visualize Counter-Strike: Global Offensive (CSGO) demo files. You can visit the repository_ to view the source code, examples and data. Please join the Discord_ server if you would like to join our esports analytics community or to receive help with the library. To install the library, run ``pip install awpy`` (Python >= 3.11).
 
 .. _repository: https://github.com/pnxenopoulos/awpy
 .. _Discord: https://discord.gg/W34XjsSs2H

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,6 +3,6 @@ Installation
 
 ``pip install awpy``
 
-To install awpy, you must have Python >= 3.9 and Go (the programming language) installed. You need a Go version greater than 1.17, and you can visit this link to install the latest `Golang version <https://go.dev/dl/>`_.
+To install awpy, you must have Python >= 3.11 and Go (the programming language) installed. You need a Go version greater than 1.18, and you can visit this link to install the latest `Golang version <https://go.dev/dl/>`_.
 
 Once you have Golang installed, you can check your version in command line by using the command ``go version``. After this, simply run ``pip install awpy``.


### PR DESCRIPTION
changed python version from 3.9 to 3.11 since many functions now rely on py3.11 stuff, which fixes the headers 

livedemo: https://awpy-docfix.readthedocs.io