### PR TITLE
map_control.py doc-fix

### DIFF
--- a/awpy/analytics/map_control.py
+++ b/awpy/analytics/map_control.py
@@ -5,8 +5,7 @@
 
     Example notebook:
 
-    # pylint: disable=line-too-long
-    github.com/pnxenopoulos/awpy/blob/main/examples/05_Map_Control_Calculations_And_Visualizations.ipynb
+    https://github.com/pnxenopoulos/awpy/blob/main/examples/05_Map_Control_Calculations_And_Visualizations.ipynb
 """
 
 from collections import defaultdict, deque


### PR DESCRIPTION
added https:// to the example link,
removed # pylint: disable=line-too-long