### PR TITLE
Fixed issue with removing rounds with bad scores.

### DIFF
--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -62,8 +62,6 @@ class DemoParser:
         demo_id (string): A unique demo name/game id.
             Default is inferred from demofile name
         output_file (str): The output file name. Default is 'demoid'+".json"
-        log (bool): A boolean indicating if the log should print to stdout.
-            Default is False
         parse_rate (int, optional): One of 128, 64, 32, 16, 8, 4, 2, or 1.
             The lower the value, the more frames are collected.
             Indicates spacing between parsed demo frames in ticks. Default is 128.
@@ -96,6 +94,7 @@ class DemoParser:
         outpath: str | None = None,
         demo_id: str | None = None,
         log: bool = False,
+        debug: bool = False,
         **parser_args: Unpack[ParserArgs],
     ) -> None:
         """Instatiate a DemoParser.
@@ -112,6 +111,9 @@ class DemoParser:
                 Default is inferred from demofile name
             log (bool, optional):
                 A boolean indicating if the log should print to stdout.
+                Default is False
+            debug (bool, optional):
+                A boolean indicating if debug output should be used.
                 Default is False
             **parser_args (ParserArgs): Further keyword args:
                 parse_rate (int, optional):
@@ -144,7 +146,7 @@ class DemoParser:
         """
         # Set up logger
         logging.basicConfig(
-            level=logging.INFO,
+            level=logging.DEBUG if debug else logging.INFO,
             format="%(asctime)s [%(levelname)s] %(message)s",
             datefmt="%H:%M:%S",
         )
@@ -223,11 +225,14 @@ class DemoParser:
         if new_json is not None:
             try:
                 TypeAdapter(Game).validate_python(new_json)
-            except ValidationError:
-                self.logger.exception(
+            except ValidationError as e:
+                # Do not always want to log the whole exception.
+                self.logger.error(  # noqa: TRY400
                     "Loaded json file does not have correct fields."
                     " This may cause issues later."
+                    " Enable debug output to see the differences."
                 )
+                self.logger.debug(e)
         self._json = new_json
 
     @property
@@ -1028,12 +1033,16 @@ class DemoParser:
         # So 19, 23, 27, ...
         # So if you substract 15 from an OT winning round
         # the number is divisible by 4
-        ot_valid_ct_win = (game_round["endCTScore"] - tie_score) % (
-            ot_tie_score + 1
-        ) == 0 and game_round["endTScore"] < game_round["endCTScore"]
-        ot_valid_t_win = (game_round["endTScore"] - tie_score) % (
-            ot_tie_score + 1
-        ) == 0 and game_round["endCTScore"] < game_round["endTScore"]
+        ot_valid_ct_win = (
+            (game_round["endCTScore"] - tie_score) % (ot_tie_score + 1) == 0
+            and game_round["endTScore"] < game_round["endCTScore"]
+            and game_round["endCTScore"] > tie_score
+        )
+        ot_valid_t_win = (
+            (game_round["endTScore"] - tie_score) % (ot_tie_score + 1) == 0
+            and game_round["endCTScore"] < game_round["endTScore"]
+            and game_round["endTScore"] > tie_score
+        )
         return (
             regular_valid_ct_win
             or regular_valid_t_win
@@ -1071,12 +1080,11 @@ class DemoParser:
                         + lookahead_round["ctScore"]
                         + lookahead_round["endCTScore"]
                     )
-
                     if (
                         # Next round should have higher score than current
                         (lookahead_round_total > current_round_total)
                         # Valid rounds have a winner and a not winner
-                        or self._has_winner_and_not_winner(game_round=game_round)
+                        or self._has_winner_and_not_winner(game_round)
                     ):
                         cleaned_rounds.append(game_round)
                 else:

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1037,12 +1037,12 @@ class DemoParser:
         # the number is divisible by 3
         ot_valid_ct_win = (
             (game_round["endCTScore"] - tie_score - 1) % ot_tie_score == 0
-            and game_round["endTScore"] < game_round["endCTScore"]
+            and game_round["endTScore"] < (game_round["endCTScore"] - 1)
             and game_round["endCTScore"] > tie_score
         )
         ot_valid_t_win = (
             (game_round["endTScore"] - tie_score - 1) % ot_tie_score == 0
-            and game_round["endCTScore"] < game_round["endTScore"]
+            and game_round["endCTScore"] < (game_round["endTScore"] - 1)
             and game_round["endTScore"] > tie_score
         )
         return (
@@ -1074,7 +1074,6 @@ class DemoParser:
                     + game_round["endCTScore"]
                 )
                 if i < len(self.json["gameRounds"]) - 1:
-                    # Non-OT rounds
                     lookahead_round = self.json["gameRounds"][i + 1]
                     lookahead_round_total = (
                         lookahead_round["tScore"]
@@ -1085,7 +1084,8 @@ class DemoParser:
                     if (
                         # Next round should have higher score than current
                         (lookahead_round_total > current_round_total)
-                        # Valid rounds have a winner and a not winner
+                        # Or the round is the final real round
+                        # with a winner and a loser
                         or self._has_winner_and_not_winner(game_round)
                     ):
                         cleaned_rounds.append(game_round)

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1037,6 +1037,9 @@ class DemoParser:
         # the number is divisible by 3
         ot_valid_ct_win = (
             (game_round["endCTScore"] - tie_score - 1) % ot_tie_score == 0
+            # Difference of two needed for a win. e.g 19-17
+            # Difference of one means that it was 18-18 and went to another
+            # overtime e.g. 19-18 and thus is not a win for one side yet.
             and game_round["endTScore"] < (game_round["endCTScore"] - 1)
             and game_round["endCTScore"] > tie_score
         )

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1028,18 +1028,20 @@ class DemoParser:
             game_round["endCTScore"] == tie_score + 1
             and game_round["endTScore"] < tie_score
         )
-        # OT win scores are of the type:
-        # 15 + (4xN) with N a natural numbers (1, 2, 3, ...)
-        # So 19, 23, 27, ...
-        # So if you substract 15 from an OT winning round
-        # the number is divisible by 4
+        # OT draw scores are of the type
+        # 15 + 3xN with N a natural number(1, 2, 3, ...)
+        # So 18, 21, 24, 27
+        # Wins are 1 higher
+        # So 19, 22, 25, 28
+        # So if you substract 15 + 1 from an OT winning round
+        # the number is divisible by 3
         ot_valid_ct_win = (
-            (game_round["endCTScore"] - tie_score) % (ot_tie_score + 1) == 0
+            (game_round["endCTScore"] - tie_score - 1) % ot_tie_score == 0
             and game_round["endTScore"] < game_round["endCTScore"]
             and game_round["endCTScore"] > tie_score
         )
         ot_valid_t_win = (
-            (game_round["endTScore"] - tie_score) % (ot_tie_score + 1) == 0
+            (game_round["endTScore"] - tie_score - 1) % ot_tie_score == 0
             and game_round["endCTScore"] < game_round["endTScore"]
             and game_round["endTScore"] > tie_score
         )

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -320,6 +320,53 @@ class TestDemoParser:
         missing_freezetime_end_data = missing_round_freezetime_end_event_parser.parse()
         assert len(missing_freezetime_end_data["gameRounds"]) == 21
 
+    def test_remove_bad_scoring_no_ot_ot_value(self):
+        """Tests that remove bad scoring works for the score 11-5.
+
+        Issue 220 raised by ozanhagen.
+        """
+        scoring_parser = DemoParser()
+        scoring_parser.json = {
+            "gameRounds": [
+                {"tScore": 0, "ctScore": 0, "endTScore": 1, "endCTScore": 0},
+                {"tScore": 0, "ctScore": 0, "endTScore": 1, "endCTScore": 0},
+                {"tScore": 1, "ctScore": 0, "endTScore": 2, "endCTScore": 0},
+                {"tScore": 2, "ctScore": 0, "endTScore": 3, "endCTScore": 0},
+                {"tScore": 3, "ctScore": 0, "endTScore": 4, "endCTScore": 0},
+                {"tScore": 4, "ctScore": 0, "endTScore": 4, "endCTScore": 1},
+                {"tScore": 4, "ctScore": 1, "endTScore": 5, "endCTScore": 1},
+                {"tScore": 5, "ctScore": 1, "endTScore": 6, "endCTScore": 1},
+                {"tScore": 6, "ctScore": 1, "endTScore": 6, "endCTScore": 2},
+                {"tScore": 6, "ctScore": 2, "endTScore": 7, "endCTScore": 2},
+                {"tScore": 7, "ctScore": 2, "endTScore": 8, "endCTScore": 2},
+                {"tScore": 8, "ctScore": 2, "endTScore": 9, "endCTScore": 2},
+                {"tScore": 9, "ctScore": 2, "endTScore": 10, "endCTScore": 2},
+                {"tScore": 10, "ctScore": 2, "endTScore": 10, "endCTScore": 3},
+                {"tScore": 10, "ctScore": 3, "endTScore": 10, "endCTScore": 4},
+                {"tScore": 10, "ctScore": 4, "endTScore": 10, "endCTScore": 5},
+                {"tScore": 5, "ctScore": 10, "endTScore": 5, "endCTScore": 11},
+                {"tScore": 5, "ctScore": 10, "endTScore": 5, "endCTScore": 11},
+                {"tScore": 5, "ctScore": 10, "endTScore": 6, "endCTScore": 10},
+                {"tScore": 5, "ctScore": 10, "endTScore": 5, "endCTScore": 11},
+                {"tScore": 5, "ctScore": 10, "endTScore": 6, "endCTScore": 10},
+                {"tScore": 6, "ctScore": 10, "endTScore": 7, "endCTScore": 10},
+                {"tScore": 7, "ctScore": 10, "endTScore": 8, "endCTScore": 10},
+                {"tScore": 8, "ctScore": 10, "endTScore": 9, "endCTScore": 10},
+                {"tScore": 9, "ctScore": 10, "endTScore": 10, "endCTScore": 10},
+                {"tScore": 10, "ctScore": 10, "endTScore": 10, "endCTScore": 11},
+                {"tScore": 10, "ctScore": 11, "endTScore": 11, "endCTScore": 11},
+                {"tScore": 11, "ctScore": 11, "endTScore": 11, "endCTScore": 12},
+                {"tScore": 11, "ctScore": 12, "endTScore": 11, "endCTScore": 13},
+                {"tScore": 11, "ctScore": 13, "endTScore": 12, "endCTScore": 13},
+                {"tScore": 12, "ctScore": 13, "endTScore": 12, "endCTScore": 14},
+                {"tScore": 12, "ctScore": 14, "endTScore": 12, "endCTScore": 15},
+                {"tScore": 12, "ctScore": 15, "endTScore": 12, "endCTScore": 16},
+                {"tScore": 0, "ctScore": 0, "endTScore": 0, "endCTScore": 1},
+            ]
+        }
+        scoring_parser.remove_bad_scoring()
+        assert len(scoring_parser.json["gameRounds"]) == 28
+
     def test_warmup(self):
         """Tests if warmup rounds are properly parsing."""
         self.warmup_parser = DemoParser(


### PR DESCRIPTION
Closes https://github.com/pnxenopoulos/awpy/issues/220

The issue was that when checking for rounds with bad scores we have logic to allow the last valid round to remain. There is special case logic for OT which was missing a check that the score was ACTUALLY in OT.