### PR TITLE
Handle ErrUnexpectedEndOfDemo gracefully.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,7 @@ dmypy.json
 .pytype/
 
 # csgo demofiles
-.dem
+*.dem
 
 # vscode
 *code-workspace

--- a/awpy/parser/parse_demo.go
+++ b/awpy/parser/parse_demo.go
@@ -2516,14 +2516,12 @@ func registerFrameHandler(demoParser *dem.Parser, currentGame *Game, currentRoun
 					appendFrameToRound(currentRound, &currentFrame, globalFrameIndex)
 				}
 			}
-
 		}
 		if *currentFrameIdx == (currentGame.ParsingOpts.ParseRate - 1) {
 			*currentFrameIdx = 0
 		} else {
 			*currentFrameIdx++
 		}
-
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/pnxenopoulos/awpy/issues/189

We now just print a warning that the error occured and to check the result if we get a `ErrUnexpectedEndOfDemo` when parsing a demo.

Also did a minor cleanup and fixed the gitignore when it comes to demo files.