### PR TITLE
Added check into frames event to correct for skipped FreezeTimeEnd events

### DIFF
--- a/awpy/parser/parse_demo.go
+++ b/awpy/parser/parse_demo.go
@@ -1266,7 +1266,6 @@ func registerRoundFreezeTimeEndHandler(demoParser *dem.Parser, currentGame *Game
 			currentRound.RoundNum = int64(len(currentGame.Rounds) + 1)
 			currentRound.StartTick = int64(gs.IngameTick() - int(currentGame.TickRate)*int(currentGame.ServerVars.FreezeTime))
 			currentRound.FreezeTimeEndTick = int64(gs.IngameTick())
-
 			setTeamValuesInRound(currentRound, &gs)
 		}
 
@@ -2380,10 +2379,29 @@ func registerDamageHandler(demoParser *dem.Parser, currentGame *Game, currentRou
 	})
 }
 
+func inFreezeTimeFromGameRules(gameState *dem.GameState) bool {
+	entity := (*gameState).Rules().Entity()
+	if entity != nil {
+		property, found := entity.PropertyValue("cs_gamerules_data.m_bFreezePeriod")
+		if found {
+			return property.BoolVal()
+		}
+	}
+
+	return false
+}
+
 func registerFrameHandler(demoParser *dem.Parser, currentGame *Game, currentRound *GameRound, smokes *[]Smoke,
 	roundInFreezetime *int, roundInEndTime *int, currentFrameIdx *int, parseFrames *bool, globalFrameIndex *int64) {
 	(*demoParser).RegisterEventHandler(func(e events.FrameDone) {
 		gs := (*demoParser).GameState()
+
+		// If the game says we are not in freeze time anymore
+		// but the toggle still thinks we are then correct the toggle
+		if !inFreezeTimeFromGameRules(&gs) && (*roundInFreezetime != 0) {
+			*roundInFreezetime = 0
+			currentRound.FreezeTimeEndTick = int64(gs.IngameTick())
+		}
 
 		if (*roundInFreezetime == 0) && (*roundInEndTime == 0) {
 			if gs.TeamCounterTerrorists() != nil {
@@ -2550,7 +2568,6 @@ func cleanAndWriteGame(currentGame *Game, jsonIndentation bool, outpath string) 
 					} else {
 						tempDamages = append(tempDamages, currentGame.Rounds[i].Damages[j])
 					}
-				} else {
 					tempDamages = append(tempDamages, currentGame.Rounds[i].Damages[j])
 				}
 			}

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -46,5 +46,8 @@
     },
     "2903_3": {
         "url": "https://figshare.com/ndownloader/files/41515014"
+    },
+    "mibr-vs-fluxo-m2-vertigo": {
+        "url": "https://figshare.com/ndownloader/files/41752629"
     }
 }

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -312,6 +312,14 @@ class TestDemoParser:
         )
         assert len(self.bad_scoring_parser_data["gameRounds"]) == 26
 
+    def test_handle_skipped_round_freezetime_end_event(self):
+        """Tests that missing RoundFreezetimeEnd does not break the parser."""
+        missing_round_freezetime_end_event_parser = DemoParser(
+            demofile="tests/mibr-vs-fluxo-m2-vertigo.dem", log=False, parse_frames=False
+        )
+        missing_freezetime_end_data = missing_round_freezetime_end_event_parser.parse()
+        assert len(missing_freezetime_end_data["gameRounds"]) == 21
+
     def test_warmup(self):
         """Tests if warmup rounds are properly parsing."""
         self.warmup_parser = DemoParser(


### PR DESCRIPTION
Closes https://github.com/pnxenopoulos/awpy/issues/196

It seems that the game rules contains a property tracking freezetime status that is more accurate than the freezetimeend event.

I have added a check into the framesdone event that fixes the `roundinfreezetime` toggle when the property says something different.

One could potentially replace that flag and event with this property entirely. But it isnt 100% trivial as it can be nil in some cases. So going with this for now.