### PR TITLE
Round cleaning and freezetime recognition improvements.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
         entry: pyright
         language: system
         types: [python]
+        pass_filenames: false
   - repo: local
     hooks:
       - id: pylint
@@ -56,6 +57,7 @@ repos:
         entry: pylint awpy
         language: system
         types: [python]
+        pass_filenames: false
         args:
           [
             "-rn", # Only display messages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,6 @@ repos:
         entry: pyright
         language: system
         types: [python]
-        pass_filenames: false
   - repo: local
     hooks:
       - id: pylint
@@ -57,7 +56,6 @@ repos:
         entry: pylint awpy
         language: system
         types: [python]
-        pass_filenames: false
         args:
           [
             "-rn", # Only display messages

--- a/awpy/parser/demoparser.py
+++ b/awpy/parser/demoparser.py
@@ -1178,28 +1178,11 @@ class DemoParser:
             AttributeError: Raises an AttributeError if the .json attribute is None
         """
         if self.json:
-            cleaned_rounds = []
-            # Remove warmups where the demo may have started recording
-            # in the middle of a warmup round
-            if "warmupChanged" in self.json["matchPhases"]:
-                if (
-                    self.json["matchPhases"]["warmupChanged"] is not None
-                    and len(self.json["matchPhases"]["warmupChanged"]) > 1
-                ):
-                    last_warmup_changed = self.json["matchPhases"]["warmupChanged"][1]
-                    for game_round in self.json["gameRounds"] or []:
-                        if (game_round["startTick"] > last_warmup_changed) and (
-                            not game_round["isWarmup"]
-                        ):
-                            cleaned_rounds.append(game_round)
-                        if game_round["startTick"] == last_warmup_changed:
-                            cleaned_rounds.append(game_round)
-                else:
-                    cleaned_rounds.extend(
-                        game_round
-                        for game_round in self.json["gameRounds"] or []
-                        if not game_round["isWarmup"]
-                    )
+            cleaned_rounds = [
+                game_round
+                for game_round in self.json["gameRounds"] or []
+                if not game_round["isWarmup"]
+            ]
             self.json["gameRounds"] = cleaned_rounds
         else:
             msg = "JSON not found. Run .parse() or .read_json() if JSON already exists"

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -49,5 +49,8 @@
     },
     "mibr-vs-fluxo-m2-vertigo": {
         "url": "https://figshare.com/ndownloader/files/41752629"
+    },
+    "cevo-pov": {
+        "url": "https://figshare.com/ndownloader/files/42241986"
     }
 }

--- a/tests/test_demo_parse.py
+++ b/tests/test_demo_parse.py
@@ -388,6 +388,19 @@ class TestDemoParser:
         assert len(self.warmup_sneem_data["gameRounds"]) == 30
         self._check_round_scores(self.warmup_sneem_data["gameRounds"])
 
+    def test_284(self):
+        """Test new warmup logic and freezetime workaround.
+
+        See https://github.com/pnxenopoulos/awpy/issues/284
+        """
+        cevo_pov_parser = DemoParser(demofile="tests/cevo-pov.dem", log=False)
+        data = cevo_pov_parser.parse(clean=False)
+        # No extra rounds from freezetime workaround
+        assert len(data["gameRounds"]) == 28
+        data = cevo_pov_parser.clean_rounds()
+        # Cleans correct number of rounds.
+        assert len(data["gameRounds"]) == 21
+
     def test_bomb_sites(self):
         """Tests that both bombsite A and B show up."""
         self.bombsite_parser = DemoParser(

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,5 +1,6 @@
 """Tests visualization module."""
 import os
+import shutil
 from unittest.mock import MagicMock, patch
 
 import matplotlib as mpl
@@ -268,3 +269,4 @@ class TestVis:
         os.mkdir(AWPY_TMP_FOLDER)
         with pytest.raises(FileExistsError), with_tmp_dir():
             pass
+        shutil.rmtree(AWPY_TMP_FOLDER)


### PR DESCRIPTION
Closes https://github.com/pnxenopoulos/awpy/issues/284

This PR includes a reduction of `remove_warmups` to it simplest form due to it seeming too rigid and functionally unclear.
It now only removes rounds tagged as `isWarmup`.

This was the main reason the demo in the issue had all of its rounds removed in cleaning.

---

I also adjusted `remove_bad_scoring` slightly so that it now requires rounds that are kept because they have a winning score to also have to have a higher score than the previous round.

In the cevo demo there were multiple rounds before the "last" that had the final game score.

16-5 (actual last round)
16-5 (some left over non gameplay round)
0-0 (reset round before the server closed)

As this check was not present previously this caused the "bad" second to last round to be wrongly kept. This has been fixed now.

---

Lastly the PR includes a change to freezetime/roundstart handling.

The `FreezeTimeEndHandler` handler includes a check whether the game is already (still) in freezetime to deal with cases where the `RoundStart` event did not fire. It subsequently adds the currently still  kept alive round to the list of game rounds and starts the new one from the freeze time end instead of the ideal round start.

The addition of the gamestate check for the freeze time which was added in `https://github.com/pnxenopoulos/awpy/pull/278` to handle cases where the `FrezeTimeEnd` event was missing. 

This introduced an issue when the gamestate changed before the event triggered. Causing the `roundInFreezetime` flag to be set before the event triggered which caused the event to add a lot short dummy rounds into the list of rounds.

I have now added an additional flag which indicates if the `roundInFreezetime` flag was set from the gamestate checker. If that is the case then the freezetime event handler does not add its own round.

These two flags could potentially be refactored into a single enum though. Dont know if you feel that that is necessary.