### PR TITLE
Make plot rounds respect levels

### DIFF
--- a/awpy/types.py
+++ b/awpy/types.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict
 class PlotPosition:
     """Class to store information needed for plotting a position."""
 
-    position: tuple[float, float]
+    position: tuple[float, float, float]
     color: str
     marker: str
     alpha: float | None = None


### PR DESCRIPTION
Previously plot rounds showed the two levels for maps that have them but only plotted the player and bomb in the upper half. Now it should also plot them in the lower one if they are there.