### PR TITLE
Added label options to plot method

### DIFF
--- a/awpy/plot/plot.py
+++ b/awpy/plot/plot.py
@@ -51,6 +51,8 @@ def plot(  # noqa: PLR0915
             - 'armor': int (0-100)
             - 'direction': tuple[float, float] (pitch, yaw in degrees)
             - 'label': str (optional)
+            - 'label_direction': int (default 0, optional) (location in degrees)
+            - 'label_fontsize': int (default 6, optional)
 
     Raises:
         FileNotFoundError: Raises a FileNotFoundError if the map image is not
@@ -106,6 +108,8 @@ def plot(  # noqa: PLR0915
             armor = settings.get("armor")
             direction = settings.get("direction")
             label = settings.get("label")
+            label_direction = settings.get("label_direction", 0)
+            label_fontsize = settings.get("label_fontsize",6)
 
             alpha = 0.15 if hp == 0 else 1.0
 
@@ -219,19 +223,23 @@ def plot(  # noqa: PLR0915
 
             # Add label
             if label:
-                label_offset = vertical_offset + 1.25 * bar_width
+                radians = math.radians(label_direction % 360)
+                label_vertical_offset = 2*(size+label_fontsize)
+                label_horizontal_offset = 1.5*(size+len(label)*label_fontsize)
+                label_offset_x = math.sin(radians) * (label_horizontal_offset)
+                label_offset_y = math.cos(radians) * (label_vertical_offset)
                 axes.annotate(
                     label,
-                    (transformed_x, transformed_y - label_offset),
+                    (transformed_x + label_offset_x, transformed_y - label_offset_y),
                     xytext=(0, 0),
                     textcoords="offset points",
                     color="white",
-                    fontsize=6,
+                    fontsize=label_fontsize,
                     alpha=alpha,
                     zorder=13,
                     ha="center",
-                    va="top",
-                )  # Center the text horizontally
+                    va="center",
+                )  # Center the text horizontally and vertically
 
     figure.patch.set_facecolor("black")
     plt.tight_layout()


### PR DESCRIPTION
Added label_direction and label_fontsize as optional parameters in the point_settings dictionary, in the plot method.

label_fontsize specifies the size of the font for the label of a given point (defaults to 6, old hard coded parameter)

label_direction specifies the location of the label in relation to the dot. Defaults to 0 - above the point. 90 would place the label to the right of the point, 180 below, 270 directly to the left etc.

Please note two things: 
- i hardcoded the label_horizontal_offset value. The alternative was to create another pyplot figure, plotting the label there and getting the length from text_object.get_window_extent(renderer=renderer). That seemed like it would slow down the time of execution too much. The hardcoded value works best for labels of length 5-10. 
- Aesthetically it made more sense for me for the label to be on top of the HP/armor bars, instead of enlarging/adjusting the position of the ellipse on which the label is plotted. see pics below: 
- 
![image](https://github.com/user-attachments/assets/6cc110a0-efd8-458e-9380-357c7f4b2dfc)
![image](https://github.com/user-attachments/assets/4b3c3596-4459-4feb-9e9a-c5735fd0fc04)

