### PR TITLE
fix round end official ticks

### DIFF
--- a/awpy/demo.py
+++ b/awpy/demo.py
@@ -256,9 +256,9 @@ class Demo:
         # Parse, filter, and apply round number to ticks
         self.ticks = self.parse_ticks(player_props=player_props)
         self.ticks = self.ticks.filter(pl.col("tick").is_in(self.in_play_ticks))
-        self.ticks = awpy.parsers.rounds.apply_round_num(
-            df=self.ticks, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        self.ticks = awpy.parsers.rounds.apply_round_num(df=self.ticks, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
         self.ticks = awpy.parsers.utils.fix_common_names(self.ticks)
 
         # Parse, filter, and apply round number to grenades
@@ -268,9 +268,7 @@ class Demo:
             df=self.grenades, rounds_df=self.rounds, tick_col="tick"
         ).filter(pl.col("round_num").is_not_null())
 
-        logger.success(
-            f"Finished parsing {self.path}, took {time.perf_counter() - start:.2f} seconds"
-        )
+        logger.success(f"Finished parsing {self.path}, took {time.perf_counter() - start:.2f} seconds")
 
     @cached_property
     def infernos(self) -> pl.DataFrame:
@@ -286,19 +284,13 @@ class Demo:
             KeyError: If the necessary inferno events ("inferno_startburn" or "inferno_expire")
                         are not found in the parsed events.
         """
-        starts = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "inferno_startburn"
-        )
-        ends = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "inferno_expire"
-        )
+        starts = awpy.parsers.utils.get_event_from_parsed_events(self.events, "inferno_startburn")
+        ends = awpy.parsers.utils.get_event_from_parsed_events(self.events, "inferno_expire")
         duration_in_ticks = self.tickrate * self.inferno_duration
-        infernos = awpy.parsers.grenades.parse_timed_grenade_entity(
-            starts, ends, duration_in_ticks
+        infernos = awpy.parsers.grenades.parse_timed_grenade_entity(starts, ends, duration_in_ticks)
+        return awpy.parsers.rounds.apply_round_num(df=infernos, rounds_df=self.rounds, tick_col="start_tick").filter(
+            pl.col("round_num").is_not_null()
         )
-        return awpy.parsers.rounds.apply_round_num(
-            df=infernos, rounds_df=self.rounds, tick_col="start_tick"
-        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def smokes(self) -> pl.DataFrame:
@@ -314,19 +306,13 @@ class Demo:
             KeyError: If the necessary smoke grenade events ("smokegrenade_detonate" or "smokegrenade_expired")
                         are not found in the parsed events.
         """
-        starts = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "smokegrenade_detonate"
-        )
-        ends = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "smokegrenade_expired"
-        )
+        starts = awpy.parsers.utils.get_event_from_parsed_events(self.events, "smokegrenade_detonate")
+        ends = awpy.parsers.utils.get_event_from_parsed_events(self.events, "smokegrenade_expired")
         duration_in_ticks = self.tickrate * self.smoke_duration
-        smokes = awpy.parsers.grenades.parse_timed_grenade_entity(
-            starts, ends, duration_in_ticks
+        smokes = awpy.parsers.grenades.parse_timed_grenade_entity(starts, ends, duration_in_ticks)
+        return awpy.parsers.rounds.apply_round_num(df=smokes, rounds_df=self.rounds, tick_col="start_tick").filter(
+            pl.col("round_num").is_not_null()
         )
-        return awpy.parsers.rounds.apply_round_num(
-            df=smokes, rounds_df=self.rounds, tick_col="start_tick"
-        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def kills(self) -> pl.DataFrame:
@@ -343,13 +329,11 @@ class Demo:
             KeyError: If 'player_death' events are not found in the parsed events, which likely indicates
                     that the demo has not been parsed yet. In this case, please run the .parse() method.
         """
-        kills = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "player_death"
-        )
+        kills = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_death")
         kills = awpy.parsers.events.parse_kills(kills)
-        return awpy.parsers.rounds.apply_round_num(
-            df=kills, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        return awpy.parsers.rounds.apply_round_num(df=kills, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
 
     @cached_property
     def damages(self) -> pl.DataFrame:
@@ -366,13 +350,11 @@ class Demo:
             KeyError: If 'player_hurt' events are not found in the parsed events, which likely indicates
                     that the demo has not been parsed yet. In this case, please run the .parse() method.
         """
-        damages = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "player_hurt"
-        )
+        damages = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_hurt")
         damages = awpy.parsers.events.parse_damages(damages)
-        return awpy.parsers.rounds.apply_round_num(
-            df=damages, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        return awpy.parsers.rounds.apply_round_num(df=damages, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
 
     @cached_property
     def footsteps(self) -> pl.DataFrame:
@@ -390,13 +372,11 @@ class Demo:
             KeyError: If 'player_sound' events are not found in the parsed events. This may
                     indicate that the demo has not been parsed yet. Please run the .parse() method.
         """
-        footsteps = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "player_sound"
-        )
+        footsteps = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_sound")
         footsteps = awpy.parsers.events.parse_footsteps(footsteps)
-        return awpy.parsers.rounds.apply_round_num(
-            df=footsteps, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        return awpy.parsers.rounds.apply_round_num(df=footsteps, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
 
     @cached_property
     def shots(self) -> pl.DataFrame:
@@ -415,13 +395,11 @@ class Demo:
             KeyError: If 'weapon_fire' events are not found in the parsed events. This may
                     indicate that the demo has not been parsed yet. Please run the .parse() method.
         """
-        shots = awpy.parsers.utils.get_event_from_parsed_events(
-            self.events, "weapon_fire"
-        )
+        shots = awpy.parsers.utils.get_event_from_parsed_events(self.events, "weapon_fire")
         shots = awpy.parsers.events.parse_shots(shots)
-        return awpy.parsers.rounds.apply_round_num(
-            df=shots, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        return awpy.parsers.rounds.apply_round_num(df=shots, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
 
     @cached_property
     def bomb(self) -> pl.DataFrame:
@@ -448,9 +426,9 @@ class Demo:
             KeyError: If the necessary bomb event data is missing from the parsed events.
         """
         bomb = awpy.parsers.bomb.parse_bomb(self.events, self.in_play_ticks)
-        return awpy.parsers.rounds.apply_round_num(
-            df=bomb, rounds_df=self.rounds, tick_col="tick"
-        ).filter(pl.col("round_num").is_not_null())
+        return awpy.parsers.rounds.apply_round_num(df=bomb, rounds_df=self.rounds, tick_col="tick").filter(
+            pl.col("round_num").is_not_null()
+        )
 
     @cached_property
     def player_round_totals(self) -> pl.DataFrame:
@@ -475,19 +453,15 @@ class Demo:
                 - side (str): The team side ("ct", "t", or "all" for total rounds).
                 - n_rounds (int): The number of rounds played by the player on the given side.
         """
-        player_sides_by_round = self.ticks.select(
-            ["name", "steamid", "side", "round_num"]
-        ).unique()
+        player_sides_by_round = self.ticks.select(["name", "steamid", "side", "round_num"]).unique()
 
         # Merge with rounds DataFrame on "round".
-        player_sides_by_round = player_sides_by_round.join(
-            self.rounds, on="round_num", how="inner"
-        )
+        player_sides_by_round = player_sides_by_round.join(self.rounds, on="round_num", how="inner")
 
         # Aggregate rounds by player and team (i.e. side).
-        player_side_rounds = player_sides_by_round.group_by(
-            ["name", "steamid", "side"]
-        ).agg(pl.count("round_num").alias("n_rounds"))
+        player_side_rounds = player_sides_by_round.group_by(["name", "steamid", "side"]).agg(
+            pl.count("round_num").alias("n_rounds")
+        )
 
         # Aggregate total rounds by player (regardless of team) and label as "all".
         player_total_rounds = (
@@ -596,31 +570,21 @@ class Demo:
         # Loop through and process each event
         for event_name, event in events.items():
             # Convert the event from a pandas DataFrame to a Polars DataFrame.
-            events[event_name] = awpy.parsers.utils.fix_common_names(
-                pl.from_pandas(event)
-            )
+            events[event_name] = awpy.parsers.utils.fix_common_names(pl.from_pandas(event))
             if event_name == "round_start":
                 # Label the event as 'start'
-                events[event_name] = events[event_name].with_columns(
-                    pl.lit("start").alias("event")
-                )
+                events[event_name] = events[event_name].with_columns(pl.lit("start").alias("event"))
             elif event_name == "round_end":
                 # Label the event as 'end' and filter for rows with a valid winner.
                 events[event_name] = (
-                    events[event_name]
-                    .with_columns(pl.lit("end").alias("event"))
-                    .filter(pl.col("winner").is_not_null())
+                    events[event_name].with_columns(pl.lit("end").alias("event")).filter(pl.col("winner").is_not_null())
                 )
             elif event_name == "round_officially_ended":
                 # Label the event as 'official_end'
-                events[event_name] = events[event_name].with_columns(
-                    pl.lit("official_end").alias("event")
-                )
+                events[event_name] = events[event_name].with_columns(pl.lit("official_end").alias("event"))
             elif event_name == "round_freeze_end":
                 # Label the event as 'freeze_end'
-                events[event_name] = events[event_name].with_columns(
-                    pl.lit("freeze_end").alias("event")
-                )
+                events[event_name] = events[event_name].with_columns(pl.lit("freeze_end").alias("event"))
         return events
 
     def parse_ticks(
@@ -644,9 +608,7 @@ class Demo:
         self._raise_if_no_parser()
         player_props = player_props if player_props is not None else []
         other_props = other_props if other_props is not None else []
-        return pl.from_pandas(
-            self.parser.parse_ticks(wanted_props=player_props + other_props)
-        )
+        return pl.from_pandas(self.parser.parse_ticks(wanted_props=player_props + other_props))
 
     def parse_grenades(self) -> pl.DataFrame:
         """Parse grenade event data from the demo file.
@@ -659,7 +621,7 @@ class Demo:
         """
         self._raise_if_no_parser()
         grenade_df = self.parser.parse_grenades()
-        grenade_df = grenade_df.rename(columns={"name": "thrower"})
+        grenade_df = grenade_df.rename(columns={"name": "thrower", "steamid": "thrower_steamid"})
         grenade_df = pl.from_pandas(grenade_df)
         return grenade_df.select(
             [
@@ -715,6 +677,4 @@ class Demo:
                 json.dump(self.header, f)
             zipf.write(header_filename, arcname="header.json")
 
-            logger.success(
-                f"Compressed demo data saved to {zip_name}, took {time.perf_counter() - start:.2f} seconds"
-            )
+            logger.success(f"Compressed demo data saved to {zip_name}, took {time.perf_counter() - start:.2f} seconds")

--- a/awpy/demo.py
+++ b/awpy/demo.py
@@ -256,9 +256,9 @@ class Demo:
         # Parse, filter, and apply round number to ticks
         self.ticks = self.parse_ticks(player_props=player_props)
         self.ticks = self.ticks.filter(pl.col("tick").is_in(self.in_play_ticks))
-        self.ticks = awpy.parsers.rounds.apply_round_num(df=self.ticks, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
-        )
+        self.ticks = awpy.parsers.rounds.apply_round_num(
+            df=self.ticks, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
         self.ticks = awpy.parsers.utils.fix_common_names(self.ticks)
 
         # Parse, filter, and apply round number to grenades
@@ -268,7 +268,9 @@ class Demo:
             df=self.grenades, rounds_df=self.rounds, tick_col="tick"
         ).filter(pl.col("round_num").is_not_null())
 
-        logger.success(f"Finished parsing {self.path}, took {time.perf_counter() - start:.2f} seconds")
+        logger.success(
+            f"Finished parsing {self.path}, took {time.perf_counter() - start:.2f} seconds"
+        )
 
     @cached_property
     def infernos(self) -> pl.DataFrame:
@@ -284,13 +286,19 @@ class Demo:
             KeyError: If the necessary inferno events ("inferno_startburn" or "inferno_expire")
                         are not found in the parsed events.
         """
-        starts = awpy.parsers.utils.get_event_from_parsed_events(self.events, "inferno_startburn")
-        ends = awpy.parsers.utils.get_event_from_parsed_events(self.events, "inferno_expire")
-        duration_in_ticks = self.tickrate * self.inferno_duration
-        infernos = awpy.parsers.grenades.parse_timed_grenade_entity(starts, ends, duration_in_ticks)
-        return awpy.parsers.rounds.apply_round_num(df=infernos, rounds_df=self.rounds, tick_col="start_tick").filter(
-            pl.col("round_num").is_not_null()
+        starts = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "inferno_startburn"
         )
+        ends = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "inferno_expire"
+        )
+        duration_in_ticks = self.tickrate * self.inferno_duration
+        infernos = awpy.parsers.grenades.parse_timed_grenade_entity(
+            starts, ends, duration_in_ticks
+        )
+        return awpy.parsers.rounds.apply_round_num(
+            df=infernos, rounds_df=self.rounds, tick_col="start_tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def smokes(self) -> pl.DataFrame:
@@ -306,13 +314,19 @@ class Demo:
             KeyError: If the necessary smoke grenade events ("smokegrenade_detonate" or "smokegrenade_expired")
                         are not found in the parsed events.
         """
-        starts = awpy.parsers.utils.get_event_from_parsed_events(self.events, "smokegrenade_detonate")
-        ends = awpy.parsers.utils.get_event_from_parsed_events(self.events, "smokegrenade_expired")
-        duration_in_ticks = self.tickrate * self.smoke_duration
-        smokes = awpy.parsers.grenades.parse_timed_grenade_entity(starts, ends, duration_in_ticks)
-        return awpy.parsers.rounds.apply_round_num(df=smokes, rounds_df=self.rounds, tick_col="start_tick").filter(
-            pl.col("round_num").is_not_null()
+        starts = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "smokegrenade_detonate"
         )
+        ends = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "smokegrenade_expired"
+        )
+        duration_in_ticks = self.tickrate * self.smoke_duration
+        smokes = awpy.parsers.grenades.parse_timed_grenade_entity(
+            starts, ends, duration_in_ticks
+        )
+        return awpy.parsers.rounds.apply_round_num(
+            df=smokes, rounds_df=self.rounds, tick_col="start_tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def kills(self) -> pl.DataFrame:
@@ -329,11 +343,13 @@ class Demo:
             KeyError: If 'player_death' events are not found in the parsed events, which likely indicates
                     that the demo has not been parsed yet. In this case, please run the .parse() method.
         """
-        kills = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_death")
-        kills = awpy.parsers.events.parse_kills(kills)
-        return awpy.parsers.rounds.apply_round_num(df=kills, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
+        kills = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "player_death"
         )
+        kills = awpy.parsers.events.parse_kills(kills)
+        return awpy.parsers.rounds.apply_round_num(
+            df=kills, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def damages(self) -> pl.DataFrame:
@@ -350,11 +366,13 @@ class Demo:
             KeyError: If 'player_hurt' events are not found in the parsed events, which likely indicates
                     that the demo has not been parsed yet. In this case, please run the .parse() method.
         """
-        damages = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_hurt")
-        damages = awpy.parsers.events.parse_damages(damages)
-        return awpy.parsers.rounds.apply_round_num(df=damages, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
+        damages = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "player_hurt"
         )
+        damages = awpy.parsers.events.parse_damages(damages)
+        return awpy.parsers.rounds.apply_round_num(
+            df=damages, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def footsteps(self) -> pl.DataFrame:
@@ -372,11 +390,13 @@ class Demo:
             KeyError: If 'player_sound' events are not found in the parsed events. This may
                     indicate that the demo has not been parsed yet. Please run the .parse() method.
         """
-        footsteps = awpy.parsers.utils.get_event_from_parsed_events(self.events, "player_sound")
-        footsteps = awpy.parsers.events.parse_footsteps(footsteps)
-        return awpy.parsers.rounds.apply_round_num(df=footsteps, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
+        footsteps = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "player_sound"
         )
+        footsteps = awpy.parsers.events.parse_footsteps(footsteps)
+        return awpy.parsers.rounds.apply_round_num(
+            df=footsteps, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def shots(self) -> pl.DataFrame:
@@ -395,11 +415,13 @@ class Demo:
             KeyError: If 'weapon_fire' events are not found in the parsed events. This may
                     indicate that the demo has not been parsed yet. Please run the .parse() method.
         """
-        shots = awpy.parsers.utils.get_event_from_parsed_events(self.events, "weapon_fire")
-        shots = awpy.parsers.events.parse_shots(shots)
-        return awpy.parsers.rounds.apply_round_num(df=shots, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
+        shots = awpy.parsers.utils.get_event_from_parsed_events(
+            self.events, "weapon_fire"
         )
+        shots = awpy.parsers.events.parse_shots(shots)
+        return awpy.parsers.rounds.apply_round_num(
+            df=shots, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def bomb(self) -> pl.DataFrame:
@@ -426,9 +448,9 @@ class Demo:
             KeyError: If the necessary bomb event data is missing from the parsed events.
         """
         bomb = awpy.parsers.bomb.parse_bomb(self.events, self.in_play_ticks)
-        return awpy.parsers.rounds.apply_round_num(df=bomb, rounds_df=self.rounds, tick_col="tick").filter(
-            pl.col("round_num").is_not_null()
-        )
+        return awpy.parsers.rounds.apply_round_num(
+            df=bomb, rounds_df=self.rounds, tick_col="tick"
+        ).filter(pl.col("round_num").is_not_null())
 
     @cached_property
     def player_round_totals(self) -> pl.DataFrame:
@@ -453,15 +475,19 @@ class Demo:
                 - side (str): The team side ("ct", "t", or "all" for total rounds).
                 - n_rounds (int): The number of rounds played by the player on the given side.
         """
-        player_sides_by_round = self.ticks.select(["name", "steamid", "side", "round_num"]).unique()
+        player_sides_by_round = self.ticks.select(
+            ["name", "steamid", "side", "round_num"]
+        ).unique()
 
         # Merge with rounds DataFrame on "round".
-        player_sides_by_round = player_sides_by_round.join(self.rounds, on="round_num", how="inner")
+        player_sides_by_round = player_sides_by_round.join(
+            self.rounds, on="round_num", how="inner"
+        )
 
         # Aggregate rounds by player and team (i.e. side).
-        player_side_rounds = player_sides_by_round.group_by(["name", "steamid", "side"]).agg(
-            pl.count("round_num").alias("n_rounds")
-        )
+        player_side_rounds = player_sides_by_round.group_by(
+            ["name", "steamid", "side"]
+        ).agg(pl.count("round_num").alias("n_rounds"))
 
         # Aggregate total rounds by player (regardless of team) and label as "all".
         player_total_rounds = (
@@ -570,21 +596,31 @@ class Demo:
         # Loop through and process each event
         for event_name, event in events.items():
             # Convert the event from a pandas DataFrame to a Polars DataFrame.
-            events[event_name] = awpy.parsers.utils.fix_common_names(pl.from_pandas(event))
+            events[event_name] = awpy.parsers.utils.fix_common_names(
+                pl.from_pandas(event)
+            )
             if event_name == "round_start":
                 # Label the event as 'start'
-                events[event_name] = events[event_name].with_columns(pl.lit("start").alias("event"))
+                events[event_name] = events[event_name].with_columns(
+                    pl.lit("start").alias("event")
+                )
             elif event_name == "round_end":
                 # Label the event as 'end' and filter for rows with a valid winner.
                 events[event_name] = (
-                    events[event_name].with_columns(pl.lit("end").alias("event")).filter(pl.col("winner").is_not_null())
+                    events[event_name]
+                    .with_columns(pl.lit("end").alias("event"))
+                    .filter(pl.col("winner").is_not_null())
                 )
             elif event_name == "round_officially_ended":
                 # Label the event as 'official_end'
-                events[event_name] = events[event_name].with_columns(pl.lit("official_end").alias("event"))
+                events[event_name] = events[event_name].with_columns(
+                    pl.lit("official_end").alias("event")
+                )
             elif event_name == "round_freeze_end":
                 # Label the event as 'freeze_end'
-                events[event_name] = events[event_name].with_columns(pl.lit("freeze_end").alias("event"))
+                events[event_name] = events[event_name].with_columns(
+                    pl.lit("freeze_end").alias("event")
+                )
         return events
 
     def parse_ticks(
@@ -608,7 +644,9 @@ class Demo:
         self._raise_if_no_parser()
         player_props = player_props if player_props is not None else []
         other_props = other_props if other_props is not None else []
-        return pl.from_pandas(self.parser.parse_ticks(wanted_props=player_props + other_props))
+        return pl.from_pandas(
+            self.parser.parse_ticks(wanted_props=player_props + other_props)
+        )
 
     def parse_grenades(self) -> pl.DataFrame:
         """Parse grenade event data from the demo file.
@@ -622,6 +660,7 @@ class Demo:
         self._raise_if_no_parser()
         grenade_df = self.parser.parse_grenades()
         grenade_df = grenade_df.rename(columns={"name": "thrower"})
+        logger.warning(f"{grenade_df.columns}")
         return pl.from_pandas(
             grenade_df[
                 [
@@ -678,4 +717,6 @@ class Demo:
                 json.dump(self.header, f)
             zipf.write(header_filename, arcname="header.json")
 
-            logger.success(f"Compressed demo data saved to {zip_name}, took {time.perf_counter() - start:.2f} seconds")
+            logger.success(
+                f"Compressed demo data saved to {zip_name}, took {time.perf_counter() - start:.2f} seconds"
+            )

--- a/awpy/demo.py
+++ b/awpy/demo.py
@@ -660,19 +660,17 @@ class Demo:
         self._raise_if_no_parser()
         grenade_df = self.parser.parse_grenades()
         grenade_df = grenade_df.rename(columns={"name": "thrower"})
-        logger.warning(f"{grenade_df.columns}")
-        return pl.from_pandas(
-            grenade_df[
-                [
-                    "thrower_steamid",
-                    "thrower",
-                    "grenade_type",
-                    "tick",
-                    "X",
-                    "Y",
-                    "Z",
-                    "entity_id",
-                ]
+        grenade_df = pl.from_pandas(grenade_df)
+        return grenade_df.select(
+            [
+                "thrower_steamid",
+                "thrower",
+                "grenade_type",
+                "tick",
+                "X",
+                "Y",
+                "Z",
+                "entity_id",
             ]
         )
 

--- a/awpy/demo.py
+++ b/awpy/demo.py
@@ -621,7 +621,16 @@ class Demo:
         """
         self._raise_if_no_parser()
         grenade_df = self.parser.parse_grenades()
-        grenade_df = grenade_df.rename(columns={"name": "thrower", "steamid": "thrower_steamid"})
+        grenade_df = grenade_df.rename(
+            columns={
+                "name": "thrower",
+                "steamid": "thrower_steamid",
+                "x": "X",
+                "y": "Y",
+                "z": "Z",
+                "grenade_entity_id": "entity_id",
+            }
+        )
         grenade_df = pl.from_pandas(grenade_df)
         return grenade_df.select(
             [

--- a/awpy/parsers/rounds.py
+++ b/awpy/parsers/rounds.py
@@ -7,7 +7,9 @@ import awpy.converters
 import awpy.parsers.utils
 
 
-def _find_valid_round_indices(rounds_df: pl.DataFrame, full_sequence: list[str]) -> list[int]:
+def _find_valid_round_indices(
+    rounds_df: pl.DataFrame, full_sequence: list[str]
+) -> list[int]:
     """Identify indices in the rounds DataFrame that form a valid round sequence.
 
     A valid sequence is defined as either:
@@ -44,10 +46,16 @@ def _find_valid_round_indices(rounds_df: pl.DataFrame, full_sequence: list[str])
         elif current_sequence == alt_sequence1:
             valid_indices.extend(range(i, i + len(alt_sequence1)))
         # 3. Check for a 3-event sequence: ["start", "end", "official_end"].
-        elif len(current_sequence) >= len(alt_sequence2) and current_sequence[: len(alt_sequence2)] == alt_sequence2:
+        elif (
+            len(current_sequence) >= len(alt_sequence2)
+            and current_sequence[: len(alt_sequence2)] == alt_sequence2
+        ):
             valid_indices.extend(range(i, i + len(alt_sequence2)))
         # 4. Check for a 2-event sequence: ["start", "end"].
-        elif len(current_sequence) == len(alt_sequence3) and current_sequence == alt_sequence3:
+        elif (
+            len(current_sequence) == len(alt_sequence3)
+            and current_sequence == alt_sequence3
+        ):
             valid_indices.extend(range(i, i + len(alt_sequence3)))
         # 5. Lastly, if we're at the very end and only have 3 events, check if they match the first three events of full
         elif (
@@ -60,7 +68,9 @@ def _find_valid_round_indices(rounds_df: pl.DataFrame, full_sequence: list[str])
     return valid_indices
 
 
-def _add_bomb_plant_info(rounds_df: pl.DataFrame, bomb_plants: pl.DataFrame) -> pl.DataFrame:
+def _add_bomb_plant_info(
+    rounds_df: pl.DataFrame, bomb_plants: pl.DataFrame
+) -> pl.DataFrame:
     """Add bomb plant tick and site information to the rounds DataFrame.
 
     For each round, this function looks for bomb plant events occurring between
@@ -88,11 +98,15 @@ def _add_bomb_plant_info(rounds_df: pl.DataFrame, bomb_plants: pl.DataFrame) -> 
         start_tick = rounds_df["start"][i]
         end_tick = rounds_df["end"][i]
         # Filter bomb plant events that occur within the current round's tick range.
-        plant_events = bomb_plants.filter((pl.col("tick") >= start_tick) & (pl.col("tick") <= end_tick))
+        plant_events = bomb_plants.filter(
+            (pl.col("tick") >= start_tick) & (pl.col("tick") <= end_tick)
+        )
         if len(plant_events) > 0:
             # Use the first bomb plant event for this round.
             bomb_plant_ticks[i] = plant_events["tick"][0]
-            bomb_plant_sites[i] = "bombsite_a" if plant_events["site"][0] == 220 else "bombsite_b"
+            bomb_plant_sites[i] = (
+                "bombsite_a" if plant_events["site"][0] == 220 else "bombsite_b"
+            )
 
     # Add the bomb plant information as new columns.
     return rounds_df.with_columns(
@@ -129,8 +143,12 @@ def create_round_df(events: dict[str, pl.DataFrame]) -> pl.DataFrame:
     # Retrieve required event DataFrames.
     round_start = awpy.parsers.utils.get_event_from_parsed_events(events, "round_start")
     round_end = awpy.parsers.utils.get_event_from_parsed_events(events, "round_end")
-    round_end_official = awpy.parsers.utils.get_event_from_parsed_events(events, "round_officially_ended")
-    round_freeze_end = awpy.parsers.utils.get_event_from_parsed_events(events, "round_freeze_end")
+    round_end_official = awpy.parsers.utils.get_event_from_parsed_events(
+        events, "round_officially_ended"
+    )
+    round_freeze_end = awpy.parsers.utils.get_event_from_parsed_events(
+        events, "round_freeze_end"
+    )
 
     # Retrieve optional bomb planted events; default to empty DataFrame if missing.
     bomb_plants = events.get("bomb_planted", pl.DataFrame())
@@ -144,7 +162,9 @@ def create_round_df(events: dict[str, pl.DataFrame]) -> pl.DataFrame:
     ]
 
     # Concatenate event DataFrames and filter out rows with tick==0 (unless event is "start").
-    rounds_df = pl.concat(event_dfs).filter(~((pl.col("tick") == 0) & (pl.col("event") != "start")))
+    rounds_df = pl.concat(event_dfs).filter(
+        ~((pl.col("tick") == 0) & (pl.col("event") != "start"))
+    )
 
     # Define an enumeration for event types.
     round_events_enum = pl.Enum(["official_end", "start", "freeze_end", "end"])
@@ -169,25 +189,39 @@ def create_round_df(events: dict[str, pl.DataFrame]) -> pl.DataFrame:
     rounds_df = rounds_df[valid_indices]
 
     # Create a round number column by cumulatively summing "start" events.
-    rounds_df = rounds_df.with_columns(round_num=(pl.col("event") == "start").cast(pl.Int8).cum_sum())
+    rounds_df = rounds_df.with_columns(
+        round_num=(pl.col("event") == "start").cast(pl.Int8).cum_sum()
+    )
 
     # Pivot the DataFrame so that each round is one row with columns for each event type.
-    rounds_df = rounds_df.pivot(index="round_num", on="event", values="tick", aggregate_function="first")
+    rounds_df = rounds_df.pivot(
+        index="round_num", on="event", values="tick", aggregate_function="first"
+    )
 
     # Join additional round details (such as winner and reason) from the round_end events.
-    rounds_df = rounds_df.join(round_end[["tick", "winner", "reason"]], left_on="end", right_on="tick")
+    rounds_df = rounds_df.join(
+        round_end[["tick", "winner", "reason"]], left_on="end", right_on="tick"
+    )
 
     # Replace winner and reason with constants
-    rounds_df = rounds_df.with_columns(
-        pl.col("winner").str.replace("CT", awpy.constants.CT_SIDE),
-    ).with_columns(
-        pl.col("winner").str.replace("TERRORIST", awpy.constants.T_SIDE),
+    rounds_df = (
+        rounds_df.with_columns(
+            pl.col("winner").str.replace("CT", awpy.constants.CT_SIDE),
+        )
+        .with_columns(
+            pl.col("winner").str.replace("TERRORIST", awpy.constants.T_SIDE),
+        )
+        .with_columns(
+            pl.col("winner").str.replace("T", awpy.constants.T_SIDE),
+        )
     )
 
     # Replace round number with row index (starting at 1) and coalesce official_end data.
     rounds_df = (
         rounds_df.drop("round_num")
-        .with_columns(pl.coalesce(pl.col("official_end"), pl.col("end")).alias("official_end"))
+        .with_columns(
+            pl.coalesce(pl.col("official_end"), pl.col("end")).alias("official_end")
+        )
         .with_row_index("round_num", offset=1)
     )
 
@@ -195,7 +229,9 @@ def create_round_df(events: dict[str, pl.DataFrame]) -> pl.DataFrame:
     return _add_bomb_plant_info(rounds_df, bomb_plants)
 
 
-def apply_round_num(df: pl.DataFrame, rounds_df: pl.DataFrame, tick_col: str = "tick") -> pl.DataFrame:
+def apply_round_num(
+    df: pl.DataFrame, rounds_df: pl.DataFrame, tick_col: str = "tick"
+) -> pl.DataFrame:
     """Assign a round number to each event based on its tick value.
 
     For each row in `df`, this function finds the round from `rounds_df`
@@ -233,7 +269,10 @@ def apply_round_num(df: pl.DataFrame, rounds_df: pl.DataFrame, tick_col: str = "
     # Validate that the event tick is within the round boundaries.
     # If the tick is greater than the round's 'end', then set round_num to null.
     df_with_round = df_with_round.with_columns(
-        pl.when(pl.col(tick_col) < pl.col("official_end")).then(pl.col("round_num")).otherwise(None).alias("round_num")
+        pl.when(pl.col(tick_col) <= pl.col("official_end"))
+        .then(pl.col("round_num"))
+        .otherwise(None)
+        .alias("round_num")
     )
 
     return df_with_round.drop(["start", "official_end"])

--- a/awpy/stats/rating.py
+++ b/awpy/stats/rating.py
@@ -8,7 +8,10 @@ from awpy.stats import adr, kast
 
 
 def impact(
-    demo: awpy.demo.Demo, kills_coef: float = 2.13, assists_coef: float = 0.42, intercept: float = -0.41
+    demo: awpy.demo.Demo,
+    kills_coef: float = 2.13,
+    assists_coef: float = 0.42,
+    intercept: float = -0.41,
 ) -> pl.DataFrame:
     """Calculates impact rating using Polars.
 
@@ -84,20 +87,20 @@ def impact(
 
     stats_total = (
         demo.player_round_totals.filter(pl.col("side") == "all")
-        .join(kills_total, on=["name", "steamid"], how="left")
-        .join(assists_total, on=["name", "steamid"], how="left")
+        .join(kills_total, on=["name", "steamid"], how="left", suffix="_kills")
+        .join(assists_total, on=["name", "steamid"], how="left", suffix="_assists")
         .fill_null(0)
     )
     stats_ct = (
         demo.player_round_totals.filter(pl.col("side") == "ct")
-        .join(kills_ct, on=["name", "steamid"], how="left")
-        .join(assists_ct, on=["name", "steamid"], how="left")
+        .join(kills_ct, on=["name", "steamid"], how="left", suffix="_kills")
+        .join(assists_ct, on=["name", "steamid"], how="left", suffix="_assists")
         .fill_null(0)
     )
     stats_t = (
         demo.player_round_totals.filter(pl.col("side") == "t")
-        .join(kills_t, on=["name", "steamid"], how="left")
-        .join(assists_t, on=["name", "steamid"], how="left")
+        .join(kills_t, on=["name", "steamid"], how="left", suffix="_kills")
+        .join(assists_t, on=["name", "steamid"], how="left", suffix="_assists")
         .fill_null(0)
     )
 
@@ -201,10 +204,18 @@ def rating(
     # --- Merge all stats ---
     rating_df = (
         demo.player_round_totals.join(
-            kast_df.select(["name", "steamid", "side", "kast"]), on=["name", "steamid", "side"], how="left"
+            kast_df.select(["name", "steamid", "side", "kast"]),
+            on=["name", "steamid", "side"],
+            how="left",
         )
-        .join(adr_df.select(["name", "steamid", "side", "adr"]), on=["name", "steamid", "side"])
-        .join(impact_df.select(["name", "steamid", "side", "impact"]), on=["name", "steamid", "side"])
+        .join(
+            adr_df.select(["name", "steamid", "side", "adr"]),
+            on=["name", "steamid", "side"],
+        )
+        .join(
+            impact_df.select(["name", "steamid", "side", "impact"]),
+            on=["name", "steamid", "side"],
+        )
         .join(kills, on=["name", "steamid", "side"])
         .join(deaths, on=["name", "steamid", "side"])
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "click>=8.1.8",
-    "demoparser2>=0.37.0",
+    "demoparser2>=0.38.0",
     "loguru>=0.7.3",
     "matplotlib>=3.10.0",
     "networkx>=3.4.2",

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -54,14 +54,10 @@ class TestDemo:
                 "header.json",
             ]
             zipped_files = [pathlib.Path(file).name for file in zipf.namelist()]
-            assert all(
-                pathlib.Path(file).name in zipped_files for file in expected_files
-            )
+            assert all(pathlib.Path(file).name in zipped_files for file in expected_files)
 
             # Check if there is an events/ folder and it contains files
-            events_files = [
-                file for file in zipf.namelist() if file.endswith(".parquet")
-            ]
+            events_files = [file for file in zipf.namelist() if file.endswith(".parquet")]
             assert len(events_files) > 0
 
             # Check content of header as an example
@@ -71,16 +67,15 @@ class TestDemo:
 
     def test_hltv_ticks_end_official_end(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo (end to official end)."""
-        max_round_num = parsed_hltv_demo.rounds["round_num"].max()
         for end, official_end in zip(
-            parsed_hltv_demo.rounds["end"].to_list(),
-            parsed_hltv_demo.rounds["official_end"].to_list(),
+            # Do not parse the last element, which is the last round
+            parsed_hltv_demo.rounds["end"].to_list()[:-1],
+            parsed_hltv_demo.rounds["official_end"].to_list()[:-1],
             strict=False,
         ):
             assert not parsed_hltv_demo.ticks.filter(
                 pl.col("tick") >= end,
                 pl.col("tick") <= official_end,
-                pl.col("round_num") < max_round_num,
             ).is_empty()
 
     def test_hltv_ticks_start_freeze(self, parsed_hltv_demo: awpy.demo.Demo):
@@ -90,9 +85,7 @@ class TestDemo:
             parsed_hltv_demo.rounds["freeze_end"].to_list(),
             strict=False,
         ):
-            assert not parsed_hltv_demo.ticks.filter(
-                pl.col("tick") >= start, pl.col("tick") < freeze_end
-            ).is_empty()
+            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= start, pl.col("tick") < freeze_end).is_empty()
 
     def test_hltv_ticks_freeze_end(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo (freeze end to end)."""
@@ -101,9 +94,7 @@ class TestDemo:
             parsed_hltv_demo.rounds["end"].to_list(),
             strict=False,
         ):
-            assert not parsed_hltv_demo.ticks.filter(
-                pl.col("tick") >= freeze_end, pl.col("tick") < end
-            ).is_empty()
+            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= freeze_end, pl.col("tick") < end).is_empty()
 
     def test_hltv_rounds(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an HLTV demo."""
@@ -143,14 +134,7 @@ class TestDemo:
 
     def test_faceit_kills(self, parsed_faceit_demo: awpy.demo.Demo):
         """Test the kills DataFrame for a FACEIT demo."""
-        assert (
-            len(
-                parsed_faceit_demo.kills.filter(
-                    pl.col("attacker_side") != pl.col("victim_side")
-                )
-            )
-            == 165
-        )
+        assert len(parsed_faceit_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 165
 
     def test_mm_rounds(self, parsed_mm_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an MM demo."""
@@ -167,11 +151,4 @@ class TestDemo:
 
     def test_mm_kills(self, parsed_mm_demo: awpy.demo.Demo):
         """Test the kills DataFrame for an MM demo."""
-        assert (
-            len(
-                parsed_mm_demo.kills.filter(
-                    pl.col("attacker_side") != pl.col("victim_side")
-                )
-            )
-            == 42
-        )
+        assert len(parsed_mm_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 42

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -67,12 +67,17 @@ class TestDemo:
 
     def test_hltv_ticks_end_official_end(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo (end to official end)."""
+        max_round_num = parsed_hltv_demo.rounds["round_num"].max()
         for end, official_end in zip(
             parsed_hltv_demo.rounds["end"].to_list(),
             parsed_hltv_demo.rounds["official_end"].to_list(),
             strict=False,
         ):
-            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= end, pl.col("tick") < official_end).is_empty()
+            assert not parsed_hltv_demo.ticks.filter(
+                pl.col("tick") >= end,
+                pl.col("tick") < official_end,
+                pl.col("round_num") < max_round_num,
+            ).is_empty()
 
     def test_hltv_ticks_start_freeze(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo (start to freeze end)."""

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -65,14 +65,32 @@ class TestDemo:
                 header = json.load(f)
                 assert header["map_name"] == "de_nuke"
 
-    def test_hltv_ticks(self, parsed_hltv_demo: awpy.demo.Demo):
-        """Test the ticks DataFrame for an HLTV demo."""
+    def test_hltv_ticks_end_official_end(self, parsed_hltv_demo: awpy.demo.Demo):
+        """Test the ticks DataFrame for an HLTV demo (end to official end)."""
         for end, official_end in zip(
-            parsed_hltv_demo.rounds["end_tick"].to_list(),
-            parsed_hltv_demo.rounds["official_end_tick"].to_list(),
+            parsed_hltv_demo.rounds["end"].to_list(),
+            parsed_hltv_demo.rounds["official_end"].to_list(),
             strict=False,
         ):
             assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= end, pl.col("tick") < official_end).is_empty()
+
+    def test_hltv_ticks_start_freeze(self, parsed_hltv_demo: awpy.demo.Demo):
+        """Test the ticks DataFrame for an HLTV demo (start to freeze end)."""
+        for start, freeze_end in zip(
+            parsed_hltv_demo.rounds["start"].to_list(),
+            parsed_hltv_demo.rounds["freeze_end"].to_list(),
+            strict=False,
+        ):
+            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= start, pl.col("tick") < freeze_end).is_empty()
+
+    def test_hltv_ticks_freeze_end(self, parsed_hltv_demo: awpy.demo.Demo):
+        """Test the ticks DataFrame for an HLTV demo (freeze end to end)."""
+        for freeze_end, end in zip(
+            parsed_hltv_demo.rounds["freeze_end"].to_list(),
+            parsed_hltv_demo.rounds["end"].to_list(),
+            strict=False,
+        ):
+            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= freeze_end, pl.col("tick") < end).is_empty()
 
     def test_hltv_rounds(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an HLTV demo."""

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -65,6 +65,15 @@ class TestDemo:
                 header = json.load(f)
                 assert header["map_name"] == "de_nuke"
 
+    def test_hltv_ticks(self, parsed_hltv_demo: awpy.demo.Demo):
+        """Test the ticks DataFrame for an HLTV demo."""
+        for end, official_end in zip(
+            parsed_hltv_demo.ticks["end_tick"].to_list(),
+            parsed_hltv_demo.ticks["official_end_tick"].to_list(),
+            strict=False,
+        ):
+            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= end, pl.col("tick") < official_end).is_empty()
+
     def test_hltv_rounds(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an HLTV demo."""
         assert parsed_hltv_demo.rounds["reason"].to_list() == [

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -54,10 +54,14 @@ class TestDemo:
                 "header.json",
             ]
             zipped_files = [pathlib.Path(file).name for file in zipf.namelist()]
-            assert all(pathlib.Path(file).name in zipped_files for file in expected_files)
+            assert all(
+                pathlib.Path(file).name in zipped_files for file in expected_files
+            )
 
             # Check if there is an events/ folder and it contains files
-            events_files = [file for file in zipf.namelist() if file.endswith(".parquet")]
+            events_files = [
+                file for file in zipf.namelist() if file.endswith(".parquet")
+            ]
             assert len(events_files) > 0
 
             # Check content of header as an example
@@ -75,7 +79,7 @@ class TestDemo:
         ):
             assert not parsed_hltv_demo.ticks.filter(
                 pl.col("tick") >= end,
-                pl.col("tick") < official_end,
+                pl.col("tick") <= official_end,
                 pl.col("round_num") < max_round_num,
             ).is_empty()
 
@@ -86,7 +90,9 @@ class TestDemo:
             parsed_hltv_demo.rounds["freeze_end"].to_list(),
             strict=False,
         ):
-            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= start, pl.col("tick") < freeze_end).is_empty()
+            assert not parsed_hltv_demo.ticks.filter(
+                pl.col("tick") >= start, pl.col("tick") < freeze_end
+            ).is_empty()
 
     def test_hltv_ticks_freeze_end(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo (freeze end to end)."""
@@ -95,7 +101,9 @@ class TestDemo:
             parsed_hltv_demo.rounds["end"].to_list(),
             strict=False,
         ):
-            assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= freeze_end, pl.col("tick") < end).is_empty()
+            assert not parsed_hltv_demo.ticks.filter(
+                pl.col("tick") >= freeze_end, pl.col("tick") < end
+            ).is_empty()
 
     def test_hltv_rounds(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an HLTV demo."""
@@ -135,7 +143,14 @@ class TestDemo:
 
     def test_faceit_kills(self, parsed_faceit_demo: awpy.demo.Demo):
         """Test the kills DataFrame for a FACEIT demo."""
-        assert len(parsed_faceit_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 165
+        assert (
+            len(
+                parsed_faceit_demo.kills.filter(
+                    pl.col("attacker_side") != pl.col("victim_side")
+                )
+            )
+            == 165
+        )
 
     def test_mm_rounds(self, parsed_mm_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an MM demo."""
@@ -152,4 +167,11 @@ class TestDemo:
 
     def test_mm_kills(self, parsed_mm_demo: awpy.demo.Demo):
         """Test the kills DataFrame for an MM demo."""
-        assert len(parsed_mm_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 42
+        assert (
+            len(
+                parsed_mm_demo.kills.filter(
+                    pl.col("attacker_side") != pl.col("victim_side")
+                )
+            )
+            == 42
+        )

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -68,8 +68,8 @@ class TestDemo:
     def test_hltv_ticks(self, parsed_hltv_demo: awpy.demo.Demo):
         """Test the ticks DataFrame for an HLTV demo."""
         for end, official_end in zip(
-            parsed_hltv_demo.ticks["end_tick"].to_list(),
-            parsed_hltv_demo.ticks["official_end_tick"].to_list(),
+            parsed_hltv_demo.rounds["end_tick"].to_list(),
+            parsed_hltv_demo.rounds["official_end_tick"].to_list(),
             strict=False,
         ):
             assert not parsed_hltv_demo.ticks.filter(pl.col("tick") >= end, pl.col("tick") < official_end).is_empty()
@@ -112,7 +112,7 @@ class TestDemo:
 
     def test_faceit_kills(self, parsed_faceit_demo: awpy.demo.Demo):
         """Test the kills DataFrame for a FACEIT demo."""
-        assert len(parsed_faceit_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 163
+        assert len(parsed_faceit_demo.kills.filter(pl.col("attacker_side") != pl.col("victim_side"))) == 165
 
     def test_mm_rounds(self, parsed_mm_demo: awpy.demo.Demo):
         """Test the rounds DataFrame for an MM demo."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -43,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "awpy"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -265,7 +266,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -592,7 +593,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1871,7 +1872,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -81,7 +80,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
-    { name = "demoparser2", specifier = ">=0.37.0" },
+    { name = "demoparser2", specifier = ">=0.38.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "networkx", specifier = ">=3.4.2" },
@@ -266,7 +265,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -444,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "demoparser2"
-version = "0.37.0"
+version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -454,24 +453,24 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/b1/ae0faf09a20dd32bf3b655dbfc18626828f7f4999249e9a7e0912d2a58d3/demoparser2-0.37.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:837f25a873d62ca44cd8da86435564e6343f75cc2c707af2442bbd2b32c5c5a2", size = 4152070 },
-    { url = "https://files.pythonhosted.org/packages/ba/a4/04fa71dbefd5d8b181a6a44320516fd5e190091524f1a98a3d144cce1974/demoparser2-0.37.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec2cea0797ed5f806fc56480bbe35b284425232d8aac07da6f7a9de33ccf9be0", size = 3740978 },
-    { url = "https://files.pythonhosted.org/packages/24/60/84d41a31db452898be0e9d9788ddd5c9060db6450bb90ff7643206d1a932/demoparser2-0.37.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b00b56d3864e0213e32b2b73eefaec7accbdc52adf8189a37716202bf4995b8", size = 3796883 },
-    { url = "https://files.pythonhosted.org/packages/5e/43/a63b1fe50bc266fb42493e0282c68758946c2ea4819b59191b0339953019/demoparser2-0.37.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2a0c8d3197d3258b6820dae4b279f55e05370a32efc84aee074ae91b48772c1", size = 4296710 },
-    { url = "https://files.pythonhosted.org/packages/6a/dd/f9a3704eeb151f5707f232461b0f0838084e2c8bb0ceeeb1252c046321e6/demoparser2-0.37.0-cp311-cp311-win32.whl", hash = "sha256:2a965f7060b1370b97f187f812ec6466296b3a4e78b9b52f44ec8098a2adcc8f", size = 4165075 },
-    { url = "https://files.pythonhosted.org/packages/c7/a2/86558a3455ef80b675d18505ae1ff4e0bdd930c70eade4b592447f5e261f/demoparser2-0.37.0-cp311-cp311-win_amd64.whl", hash = "sha256:635af96c24c39b1c1987eaa14ccfd17fe50e55010b4d45c1364be8679aa4d0f4", size = 4618868 },
-    { url = "https://files.pythonhosted.org/packages/85/22/d1ef5e9bf929974168d67cd827eb4c4a465fb840883afe049694004f4cbc/demoparser2-0.37.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4e3d190318ce33393a3df36eeb303154bf22c61ef9919b88a58ad728359e5815", size = 4153105 },
-    { url = "https://files.pythonhosted.org/packages/2f/27/77444969610b319fcc4ebf2fbb564276fe7b9258295a643442994c76773f/demoparser2-0.37.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:14fd39f43f3f0554c0f8a8a53e64404146ac07358a84edc302979cda74e7e39f", size = 3741315 },
-    { url = "https://files.pythonhosted.org/packages/3f/ab/e1f6fd0f4ef49b24317ce7008709bf1524216defe672f5290018d2ca19c7/demoparser2-0.37.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0af25ee3f3beb8918e80fcc7607d4a027eee987f807844dd82e3a6b5e5bad88b", size = 3797012 },
-    { url = "https://files.pythonhosted.org/packages/12/7a/87f7d34f4e9e0cf6dc885bc303dc47151dffecb08824d88c4678af2b04b2/demoparser2-0.37.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351676fddff530483074a1f7dd976443da5fa0d8e5a4330e12b332f95de68600", size = 4296626 },
-    { url = "https://files.pythonhosted.org/packages/57/6f/06ba11d968493d3d8573fece09d17aed5583d377ad6fcf561117e28d0a2c/demoparser2-0.37.0-cp312-cp312-win32.whl", hash = "sha256:eb22abaecabf0e11db4d1ebdadc4509b84f0817cc0c78ed24aa26f01c83419ff", size = 4171188 },
-    { url = "https://files.pythonhosted.org/packages/06/57/cbf78725c99287755e628cdc0fb427284ec2fd868f531f9aed48bc2dd171/demoparser2-0.37.0-cp312-cp312-win_amd64.whl", hash = "sha256:c81ab014308542f39fabb730dc6ae475622afbffe60469e12010655dd25d12aa", size = 4619385 },
-    { url = "https://files.pythonhosted.org/packages/2a/a2/0d7ee1d80594bca9ee139994deeec7f31a4b4514b1bd0c9e07ad621595d6/demoparser2-0.37.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f1c0044536b77cd3e1e22d183656fb90f3bd42566d80c4f8dcd4c02bf74f3891", size = 4152596 },
-    { url = "https://files.pythonhosted.org/packages/f9/e1/7a757e4945fceacde53d0aec5b36b8c277fbe0e22d4795654c3b14a5549e/demoparser2-0.37.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6c20d0a90b140205b82328be1b504d1a911eea5b00912a59c1b0115b85b5d9ea", size = 3740885 },
-    { url = "https://files.pythonhosted.org/packages/a3/42/b83f01a43407bd78e8506e48b271d67e2579b7845014ff29021c049746af/demoparser2-0.37.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4acce255c2d4a2907e0092493806fdb95a4c6b9dc31741d7bc680b1cb831c27d", size = 3796726 },
-    { url = "https://files.pythonhosted.org/packages/a4/22/03dd2c3beb6bbb0c315400c18feccd41f4c4a558b5db673fb8c984a46427/demoparser2-0.37.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45d853fd5c3f03ab2717b447656758d0e39875beea18e5324c145ada1f87b88b", size = 4296560 },
-    { url = "https://files.pythonhosted.org/packages/be/7d/6bee16c7f6d5dc16334ee75f6a131bfc9e6dd3ef035ae9312f6bbdd601c8/demoparser2-0.37.0-cp313-cp313-win32.whl", hash = "sha256:b8718c5f5c94800cfb1b7299c52dc2dd64cc10c0a246450b1c415a87cc4be1cd", size = 4170657 },
-    { url = "https://files.pythonhosted.org/packages/63/fa/9b2733cb7529031e4bf8cf00dfb6518bc9f369a53098364725266e006788/demoparser2-0.37.0-cp313-cp313-win_amd64.whl", hash = "sha256:da623481b14f5983cea5cdadffcd199247a241025ee9c483a002f99966652424", size = 4619430 },
+    { url = "https://files.pythonhosted.org/packages/9f/3f/37d72294c559ed1669131c01cdff3b89b29be4c37b682dc0a45771227350/demoparser2-0.38.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab5dbb3c070bc808d78032519652363491c609a616e455465d02114f4a383544", size = 4151931 },
+    { url = "https://files.pythonhosted.org/packages/92/3a/f9d30eb256ba97eff0af24d4fd61356259afcfb752f5d1f492fdaf3e1f27/demoparser2-0.38.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a60ac1bc34d8d6afea7304a54ed9639069a4c966fdc9647076565f4552d85e8a", size = 3741055 },
+    { url = "https://files.pythonhosted.org/packages/0f/87/311091e8d253fd6eebae5f26e35f0c3a6baea4a8ef4ec268d565d09c8ae6/demoparser2-0.38.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ea71e9227e50c30e0e398bc9315d13cf7694ff6a6fe8798edfcdc32a1b268b4", size = 3798272 },
+    { url = "https://files.pythonhosted.org/packages/da/4e/012333360faf477f1627a658cb771fd4e66544e5b0b41ebcce5f9b2404eb/demoparser2-0.38.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2de9ab4a120ac0bb10ebc3410507724b5c83b432fe47e02c5e022b4cbbc2835", size = 4295607 },
+    { url = "https://files.pythonhosted.org/packages/b1/d1/24444c58a6e25cd103a84d7be63cb35109f1aea082de0f46c42a9c6a48e9/demoparser2-0.38.0-cp311-cp311-win32.whl", hash = "sha256:f54c0be86915d9dba3cf874809a758260499a9ff07cda87bf1e3e35f964a6633", size = 4167798 },
+    { url = "https://files.pythonhosted.org/packages/c5/51/f870f5a93ec7a4433af24a026d2facba340b821c3ecf475e040091fbcf06/demoparser2-0.38.0-cp311-cp311-win_amd64.whl", hash = "sha256:3d3c537c3904469b5e6aa5e1b07fef1e47bb70ab09ccedc57087acfeb3429fb2", size = 4619353 },
+    { url = "https://files.pythonhosted.org/packages/de/93/613a90344112707c65ac3c32be5f452d3bcf8dded08b3f6f40c62fa5e7a7/demoparser2-0.38.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b6dbd7387910ffe90eaf600003462484f6c51fb88e2e361d009bc30532ace696", size = 4149869 },
+    { url = "https://files.pythonhosted.org/packages/43/fb/377707eb94d124cf6c618087ecbf891f4decdea92e02785d1ffa2d2ba883/demoparser2-0.38.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4e833d8a5d26d1ce5af8240facfc854da9f4b2ea089649735e42e3c78b37c8c3", size = 3741100 },
+    { url = "https://files.pythonhosted.org/packages/5d/4e/bd69f26fbd419e51cc9762e6f83356068a4ad5d75803e760da33c4a6b829/demoparser2-0.38.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9755e1ca9699f2006617c254ae968fdda0a13ccbfdc817e1c3f50d8a62ac733c", size = 3796928 },
+    { url = "https://files.pythonhosted.org/packages/16/c8/7319c4c38b6e0a4d52c3289628b3d36726cbc6b7dc4c6bb312f8f71bd156/demoparser2-0.38.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d33ea5150a03f10290318845c8ff17a160cf951942b1d059932aae63559847f5", size = 4292170 },
+    { url = "https://files.pythonhosted.org/packages/87/b8/97398d930b01358ac2f3827fffec301e7c0fa3ac7d3ad8a30c9c53e3cbbd/demoparser2-0.38.0-cp312-cp312-win32.whl", hash = "sha256:e0d32cf30be60692019107368708bb10a84d4e74c9f98b5767f99eeacb0d3236", size = 4170418 },
+    { url = "https://files.pythonhosted.org/packages/9f/e5/f19bc80fbb1fe378156cbd65569c44384efc747d1b090f4a842c3087d1de/demoparser2-0.38.0-cp312-cp312-win_amd64.whl", hash = "sha256:440cec2298797bdf6e8de5dbdb21e7440ea62c75139a3cdad0d1f40b7050084b", size = 4619769 },
+    { url = "https://files.pythonhosted.org/packages/f8/23/7d7c293bd8ea3d674782f773b32c5dea90411fed1324748b1818c5aa7437/demoparser2-0.38.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:24db02cf3ad4088aa1abe7f9865e7aac0cdd0eed73862a21a62d877cbbd2500c", size = 4149247 },
+    { url = "https://files.pythonhosted.org/packages/98/a5/24bcfc12c62232d59d95495c0e416e4cddb0234b2b1beef5c0ddf485456b/demoparser2-0.38.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9d24b3c9a028fe679f17ddb4b975926c7a12020a0532a8acfa90874439a050c3", size = 3740513 },
+    { url = "https://files.pythonhosted.org/packages/01/35/56ed6c3ef5882ce8debdae51784a18ea816f8859a32dc6722eb0e559d05e/demoparser2-0.38.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a3ae31d417b65906a7a35f7141150d58d4d27c327ade031c220373cdf7d07ff", size = 3796056 },
+    { url = "https://files.pythonhosted.org/packages/0c/04/e8ca70f9f49a5d0dfaf363ddadad766083b33d776aa7c26478a0eb0693fc/demoparser2-0.38.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e3411b6578192b25fb0b0feb8286339d58fca515b985cacdf7f6dd53f8ba024", size = 4291343 },
+    { url = "https://files.pythonhosted.org/packages/1a/a0/5613747ef94dab3c40166c75cfad951490842fa80dcc07400c5fdc3f2d27/demoparser2-0.38.0-cp313-cp313-win32.whl", hash = "sha256:971146c30f61b28b3b511c5f7b4bab39ac391e494859e3106e55077d64eceb11", size = 4169036 },
+    { url = "https://files.pythonhosted.org/packages/60/ba/4a0985b0cac9c76a3e5b0a25bf9e45812813213ce42a9cd8fefcc900e858/demoparser2-0.38.0-cp313-cp313-win_amd64.whl", hash = "sha256:d7dcb6f0a01974a4b3ed152d6c65d9d8c2914744920a454419640d71b3e8d2bc", size = 4619020 },
 ]
 
 [[package]]
@@ -593,7 +592,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1872,7 +1871,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
As pointed out by btrams: "by default the parser used to filter out freeze time ticks and consider ticks between end and official_end, right now the behaviour's reversed"